### PR TITLE
Remove section saying we won't enable route services

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -77,12 +77,6 @@ title: Roadmap
 
 	 <p>We hope to enable support for Docker images in the future. If you would like to be able to push Docker images, please <a href="/support.html">contact our support team</a>, and let us know why.</p>
 
-	 <h3 class="heading-medium">Cloud Foundry route services</h3>
-		
-    
-      <p>Cloud Foundry has a feature called <a href="https://docs.cloudfoundry.org/services/route-services.html">route services</a>. This allows you to filter and transform requests before they reach application instances.</p>
-      <p>At present we don't know of any use cases for this feature amongst our users. If you would like to use it, <a href="/support.html">contact our support team</a>, providing details of what you would like to use it for.</p>
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What

Remove the roadmap section that says we won't enable route services in the near future. Because we have enabled them