### PR TITLE
Revert "Remove section saying we won't enable route services"

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -77,6 +77,12 @@ title: Roadmap
 
 	 <p>We hope to enable support for Docker images in the future. If you would like to be able to push Docker images, please <a href="/support.html">contact our support team</a>, and let us know why.</p>
 
+	 <h3 class="heading-medium">Cloud Foundry route services</h3>
+		
+    
+      <p>Cloud Foundry has a feature called <a href="https://docs.cloudfoundry.org/services/route-services.html">route services</a>. This allows you to filter and transform requests before they reach application instances.</p>
+      <p>At present we don't know of any use cases for this feature amongst our users. If you would like to use it, <a href="/support.html">contact our support team</a>, providing details of what you would like to use it for.</p>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
Reverts alphagov/paas-product-page#4

All changes to content (as opposed to technical fixes like formatting etc) should be approved by GaaP content team. I'm going to clarify the exact procedure with them this afternoon. Since this is not adding content, just deleting outdated content, this isn't a big deal, but it would be useful to have an example PR to train them with, so unmerging for now.