### PR TITLE
[#140939907] Implement rediretion of paas-roadmap to the new roadmap page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GOV.UK PaaS Product Page 
+# GOV.UK PaaS Product Page
 
 This is the source for the PaaS product page at https://www.cloud.service.gov.uk/
 
@@ -16,3 +16,20 @@ It is based on: https://github.com/alphagov/product-page-example
 Check in your changes to master.
 
 Run ./deploy - you will need the correct PaaS permissions.
+
+## Redirection rules
+
+This project adds a custom `nginx.conf` that  supports redirection for a set
+of given domains. The domains should be in the `Host` or  X-Forwarded-Host`
+(for cloudfront) of the request header.
+
+This is useful for redirecting from an old domain or add a `www` prefix,
+like `cloud.service.gov.uk` to `www.cloud.service.gov.uk`.
+
+To change configure it, add the environment variable `REDIRECT_RULES` as follows:
+
+    REDIRECT_RULES=cloud.service.gov.uk:www.cloud.service.gov.uk,government-paas-developer-docs.readthedocs.io:www.cloud.service.gov.uk
+
+You can specify variables from nginx, like `$request_uri`:
+
+    REDIRECT_RULES='government-paas-developer-docs.readthedocs.io:www.cloud.service.gov.uk$request_uri'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ It is based on: https://github.com/alphagov/product-page-example
 
 Check in your changes to master.
 
-Run ./deploy - you will need the correct PaaS permissions.
+ * Deploy to prod: Run `./deploy`
+ * Deploy for testing: `PRODUCT_ORG_NAME=paas-demo PRODUCT_SPACE_NAME=sandbox PRODUCT_APP_NAME=test-govuk-paas ./deploy`
+
+Note: you will need the correct PaaS permissions.
 
 ## Redirection rules
 

--- a/deploy
+++ b/deploy
@@ -21,6 +21,7 @@ error() {
 bundle install
 bower install
 bundle exec middleman build
+cp nginx.conf ./build/
 #cp Staticfile.auth build
 cf target -o govuk-paas -s docs
 cf push

--- a/deploy
+++ b/deploy
@@ -23,5 +23,5 @@ bower install
 bundle exec middleman build
 cp nginx.conf ./build/
 #cp Staticfile.auth build
-cf target -o govuk-paas -s docs
-cf push
+cf target -o "${PRODUCT_ORG_NAME:-govuk-paas}" -s "${PRODUCT_SPACE_NAME:-docs}"
+cf push "${PRODUCT_APP_NAME:-govuk-paas}"

--- a/deploy
+++ b/deploy
@@ -18,6 +18,8 @@ error() {
 # fi
 # echo "OK!"
 
+bundle install
+bower install
 bundle exec middleman build
 #cp Staticfile.auth build
 cf target -o govuk-paas -s docs

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,7 @@ applications:
   path: ./build
   buildpack: staticfile_buildpack
   instances: 2
+  env:
+    REDIRECT_RULES: "paas-roadmap.cloudapps.digital:www.cloud.service.gov.uk/roadmap.html"
+  hosts:
+  - paas-roadmap

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,70 @@
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  gzip_vary on;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
+      if (!-e $request_filename) {
+        rewrite ^(.*)$ / break;
+      }
+      <% end %>
+      index index.html index.htm Default.htm;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+        autoindex on;
+      <% end %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+        auth_basic "Restricted";                                #For Basic Auth
+        auth_basic_user_file <%= auth_file %>;  #For Basic Auth
+      <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$host$request_uri;
+        }
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
+        ssi on;
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
+        add_header Strict-Transport-Security "max-age=31536000";
+      <% end %>
+    }
+
+  <% unless File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_dotfiles")) %>
+    location ~ /\. {
+      deny all;
+      return 404;
+    }
+  <% end %>
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -66,5 +66,19 @@ http {
       return 404;
     }
   <% end %>
+
+  <% if ENV["REDIRECT_RULES"] %>
+  <%   ENV["REDIRECT_RULES"].split(',').each { |rule| %>
+  <%   from, to = rule.split(':') %>
+  <%   if not from.empty? and not to.empty? %>
+    if ($host = "<%= from %>") {
+      return 301 https://<%= to %>;
+    }
+    if ($http_x_forwarded_host = "<%= from %>") {
+      return 301 https://<%= to %>;
+    }
+  <%   end %>
+  <%   } %>
+  <% end %>
   }
 }


### PR DESCRIPTION
[#140939907 Delete old product page](https://www.pivotaltracker.com/story/show/140939907)

What?
----

We want to redirect anyone visiting https://paas-roadmap.cloudapps.digital/ to be redirected to https://www.cloud.service.gov.uk/roadmap.html

We will implement the logic in the application itself using a custom nginx config, and then forward the request from cloudfront (See https://github.com/alphagov/paas-cf/blob/master/terraform/cloudfront/instances.tf#L7)

We do it in a generic way, by configuring nginx based on a variable `REDIRECTION_RULES`

This is based on previous work done in https://github.com/alphagov/paas-product-page/pull/2

How to test?
-------------

If you deploy in prod, manually change the `host: paas-roadmap` to something like `my-paas-roadmap` in `manifest.yml` to avoid collisions with the old name. Revert later.

Deploy the app in a sandbox space `cf target -o paas-demo -s sandbox`

```
PRODUCT_ORG_NAME=paas-demo PRODUCT_SPACE_NAME=sandbox PRODUCT_APP_NAME=test-govuk-paas ./deploy
```

Query it passing the right header:

```
curl -H 'Host: my-paas-roadmap.cloudapps.digital' -v -k https://test-govuk-paas.cloudapps.digital
```

Delete and revert once finished

What next?
----------

After merge:

 1. Delete the old paas-roadmap `cf target -o admin -s admin` and delete it `cf delete paas-roadmap`
 2. Deploy the new app (revert any change with `git checkout master --force`) by running `./deploy`

Who?
---

Anyone but @keymon