### PR TITLE
Update roadmap to include Docker

### DIFF
--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -43,10 +43,11 @@ title: Roadmap
 
       <h2 class="heading-large">Roadmap</h2>
       <p>This roadmap is for informational purposes only and may be affected by changing priorities. You shouldn’t rely on this information for major purchasing or planning purposes.</p>
-      
+
       <h3 class="heading-medium">Near-term</h3>
 
       <ul class="list list-bullet">
+      <li>Support for cloud-based CI tools such as Travis</li>
 		  <li>Redis as a backing service</li>
 		  <li>Self-service SSL certificate management</li>
 	</ul>
@@ -54,10 +55,10 @@ title: Roadmap
 	  <h3 class="heading-medium">Medium-term</h3>
 
       <ul class="list list-bullet">
-		  <li>Elasticsearch as a backing service</li>
 		  <li>MongoDB as a backing service</li>
 		  <li>Self-service user management</li>
 		  <li>Enhanced backing service monitoring</li>
+          <li>Elasticsearch as a backing service</li>
 	</ul>
 
 		 <h3 class="heading-medium">Long-term</h3>
@@ -65,18 +66,30 @@ title: Roadmap
       <ul class="list list-bullet">
 		  <li>Private networking for applications</li>
 		  <li>User application monitoring</li>
+          <li>Onshore (UK) hosting</li>
 	</ul>
 
-	 <h2 class="heading-large">Requested features</h2>
+	 <h2 class="heading-large">Experimental features</h2>
+
+	 <p>The following features have been introduced as an Alpha, to get user feedback and gain insight into stability. We would not recommend that any services in live operation adopt these features as they may be revoked should there be significant issues. Wherever possible, we will provide four weeks notice to tenants if an Alpha feature is to be discontinued.</p>
+
+	 <h3 class="heading-medium">Docker support for public images</h3>
+
+	 <p>Cloud Foundry supports pushing a public Docker image as an application. This is currently enabled as an experimental feature, to enable the platform and our tenants to explore it further. Please note that the usual 12-factor principles apply, and Docker images should not be used for persistent storage.
+
+	 <p>We hope to expand our support for Docker images in the future. If you would like to discuss your needs in this area, please <a href="/support.html">contact our support team</a>, and let us know why.</p>
+
+   <h2 class="heading-large">Requested features</h2>
 
 	 <p>Below are the features we’ve been asked about but are not planning to develop right now, and why.</p>
 
-	 <h3 class="heading-medium">Docker</h3>
+	 <h3 class="heading-medium">Multi-cloud</h3>
 
-	 <p>Cloud Foundry supports pushing a Docker image as an application. This feature is not currently enabled on GOV.UK PaaS because allowing deployment from Docker images, where the root filesystem is controlled by the tenant, raises additional security concerns: <a href="https://github.com/cloudfoundry/diego-design-notes/blob/c59e475020a22e244c6074f89c45b55f7b1e2867/docker-support.md#docker-in-a-multi-tenant-world">see this note from the Cloud Foundry developers</a> for more details.</p>
+	 <p>This has not been a substantial need for many tenants to date. However we are monitoring the market and keen to see how this space develops.</p>
 
-	 <p>We hope to enable support for Docker images in the future. If you would like to be able to push Docker images, please <a href="/support.html">contact our support team</a>, and let us know why.</p>
+   <h3 class="heading-medium">Anti-virus scanning on uploads</h3>
 
+	 <p>This is currently only a need for one tenant with low traffic, and an alternative solution has been found. Should more services have this need we may reprioritise.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Docker previously declared something we wouldn’t do. Added text to
explain ‘experimental features’ and move Docker into it. Added some
other “not in scope” features we’ve talked about.