### PR TITLE
[#137006863] Create a request trial page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -24,7 +24,7 @@ title:
         <p class="hero__description">
           GOV.UK Platform as a Service (PaaS) is a quick, easy and cheap way to deploy and host government applications. GOV.UK PaaS manages the platform infrastructure, so you can focus on building your digital services.
         </p>
-        <a href="/support.html" role="button" class="hero-button">
+        <a href="/request-trial.html" role="button" class="hero-button">
           Ask for a trial account
         </a>
         <!-- <span class="hero-alternative-action">

--- a/source/request-trial.html.erb
+++ b/source/request-trial.html.erb
@@ -1,0 +1,99 @@
+---
+title: Trial Account
+---
+
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
+    <ol itemscope itemtype="http://schema.org/BreadcrumbList">
+        <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="https://www.gov.uk/service-toolkit#components" itemprop="item">
+                <span itemprop="name">Components</span>
+            </a>
+        </li>
+        <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="/" itemprop="item">
+                <span itemprop="name">GOV.UK PaaS</span>
+            </a>
+        </li>
+        <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="#main" itemprop="item">
+                <span itemprop="name">Trial Account</span>
+            </a>
+        </li>
+    </ol>
+</nav>
+
+<div class="container">
+    <div class="grid-row">
+
+        <div class="column-two-thirds">
+            <h1 class="heading-xlarge">Starting using GOV.UK PaaS</h1>
+
+            <p>
+              Anyone with a government email address can have a GOV.UK PaaS
+              trial account.
+            </p>
+
+            <p>
+                To request an account, contact us at
+                <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+                  gov-uk-paas-support@digital.cabinet-office.gov.uk
+                </a>
+                and tell us:
+            </p>
+
+            <ul>
+                <li>
+                  the name of your department and service team (if applicable)
+                </li>
+                <li>
+                  email addresses of the people who should have a GOV.UK PaaS
+                  account
+                </li>
+                <li>
+                  the people who should administer the account and assign roles
+                  and permissions (Org managers). Ideally, you should have at
+                  least two Org managers per account.
+                </li>
+            </ul>
+
+            <p>
+                You can use our
+                <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">
+                  Quick setup guide
+                </a>
+                to get started and deploy a test application.
+            </p>
+
+            <h2 class="heading-large">
+              Joining an existing GOV.UK PaaS account
+            </h2>
+
+            <p>
+                If your team is already using GOV.UK PaaS and you would like a
+                user account, ask an Org Manager on your team to
+                <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+                  contact us
+                </a>
+                and make a request.
+            </p>
+
+            <p>
+              Users with non-government email addresses can be added to an
+              account at the request of an Org Manager.
+            </p>
+
+            <h2 class="heading-large">Your privacy</h2>
+
+            <p>
+              We need to store data about you to provide your account. See our
+              <a href="https://docs.cloud.service.gov.uk/#privacy-policy">
+                privacy policy
+              </a>
+              for details.
+            </p>
+
+        </div>
+
+        <div class="column-one-third"></div>
+    </div>
+</div>


### PR DESCRIPTION
## What

We'd like to dedicate the support page to be holding some useful information, which means the current content will be obsolete. To remain the ability to inform user about our trial requirements, we're creating a duplicate of the current support page and by slightly modifying it, deliver any essential details to our end users.

## How to review

- Run the application with either `bundle` or `docker`.
- Check if the "Ask for a trial account" link redirects to a new page.
- Check if the content is sufficient.

## Who can review

Anyone with ruby (bundle) and node (bower) or docker setup. Not @paroxp.