### PR TITLE
[#141117303] Remove references to the API whitelist

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -39,7 +39,6 @@ title: Support
             <ul>
           
               <li>email addresses of all your staff who need access including at least two people who will administer the account (Org Managers)</li>
-             <li>a list of the IP addresses you will use to access the PaaS, so we can add them to the whitelist</li>
           </ul>
 
       <h2 class="heading-large">Joining a team</h2>


### PR DESCRIPTION
## What

We no longer have an API whitelist, so stop talking about it.

## How can I review this

Make sure we no longer mention the whitelist anywhere.