### PR TITLE
[#135953301] Place support content

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -18,43 +18,124 @@ title: Support
 
 <div class="container">
   <div class="grid-row">
-
     <div class="column-two-thirds">
-      <h1 class="heading-xlarge">Support for GOV.UK PaaS</h1>
-      <p>To find out about GOV.UK PaaS or how to use it, please send a detailed description of what you need to our support team at:</p>
+      <h1 class="heading-xlarge">How GOV.UK PaaS is supported</h1>
 
-      <!--
-      <div class="panel panel-border-wide">
-        <p>
-          
-        </p>
-      </div>
-      -->
       <p>
-      <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a></p>
+        GOV.UK PaaS is supported 24 hours a day, seven days a week by the team
+        that builds it.
+      </p>
 
-      <h2 class="heading-large">Starting a trial</h2>
+      <p>
+        On this page you can find out about the support we provide during and
+        outside of working hours, and how you can contact us to report a problem
+        or ask for help.
+      </p>
 
-      <p>If your team wants to start using GOV.UK PaaS, please send:</p>
-            <ul>
-          
-              <li>email addresses of all your staff who need access including at least two people who will administer the account (Org Managers)</li>
-          </ul>
+      <h2 class="heading-large">Support during working hours</h2>
 
-      <h2 class="heading-large">Joining a team</h2>
-        
-          <p>If your team is already using GOV.UK PaaS and you need an account, ask an Org Manager on your team to make the request.</p>
-  
-       <h2 class="heading-large">Your privacy</h2>
-   
-          <p>We need to store data about you to provide your account. See our <a href="https://docs.cloud.service.gov.uk/#privacy-policy">privacy policy</a> for details.</p>
+      <p>
+        Our office hours are 9am - 5pm Monday to Friday. During this time we
+        support:
+      </p>
 
-    </div>
-       
+      <ul>
+        <li>requests for help using GOV.UK PaaS</li>
+        <li>fixing issues and resolving incidents</li>
+      </ul>
 
+      <p>
+        We prioritise support for live services over those in development, and
+        fixing issues with the platform over answering user queries. For more
+        information on how we respond to requests, you can look at our platform
+        documentation.
+      </p>
 
-    <div class="column-one-third">
+      <p>
+        For help using GOV.UK PaaS or to report a problem with your service,
+        email us at
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+          gov-uk-paas-support@digital.cabinet-office.gov.uk
+        </a>.
+      </p>
 
+      <h2 class="heading-large">Support outside of working hours</h2>
+
+      <p>
+        Between 5pm and 9am Monday to Friday, at weekends, and during Bank
+        Holidays we provide emergency support for critical incidents affecting
+        live production services. A critical incident is where:
+      </p>
+
+      <ul>
+        <li>
+          your application is unavailable due to a problem with our platform
+        </li>
+        <li>
+          you can’t make a critical upgrade to your application because the
+          GOV.UK PaaS API isn’t available
+        </li>
+        <li>
+          you are experiencing a critical issue with your application that you
+          cannot resolve without help from the platform team.
+        </li>
+      </ul>
+
+      <p>
+        We’ll start working on the issue within 40 minutes and email you to
+        let you know. We’ll address anything that is not a critical incident
+        the next working day.
+      </p>
+
+      <h2 class="heading-large">Contacting us about a critical issue</h2>
+
+      <p>
+        To contact us about a critical issue during working hours, please use
+        our support email address,
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+          gov-uk-paas-support@digital.cabinet-office.gov.uk
+        </a>.
+      </p>
+
+      <p>
+        To contact us outside of working hours, please use the emergency email
+        address you have been given. This will raise a high priority alert and
+        could wake us up in the middle of the night, so it should only be used
+        for critical incidents.
+      </p>
+
+      <p>
+        Please do not share this email address with people outside of your
+        team.
+      </p>
+
+      <h2 class="heading-large">How to escalate support requests</h2>
+
+      <p>
+        If we are not handling your request for support in the way you would
+        expect, here is how to contact us.
+      </p>
+
+      <p>
+        During working hours, please contact a member of the product team:
+      </p>
+
+      <p>
+        Tom Dolan, senior product manager -
+        <a href="maitlo:tom.dolan@digital.cabinet-office-gov.uk">
+          tom.dolan@digital.cabinet-office-gov.uk
+        </a>
+        <br />
+        Jess O’Leary, product manager -
+        <a href="mailto:jessica.o’leary@digital.cabinet-office.gov.uk">
+          jessica.o’leary@digital.cabinet-office.gov.uk
+        </a>
+      </p>
+
+      <p>
+        Outside of working hours, please use the escalation contact
+        details you have been sent.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What

Add details about how GOV.UK PaaS is supported to the Support page of our product page, including:

- the support that's provided in-hours and how Tenants can contact us
- the support that's provided out-of-hours and how Tenants can contact us about a P1 incident

## How to review

Best to fire the application locally and read through the support page.

## Who can review

Not @paroxp