### PR TITLE
Update email address on support page

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -126,7 +126,7 @@ title: Support
           tom.dolan@digital.cabinet-office-gov.uk
         </a>
         <br />
-        Jess O’Leary, product manager -
+        Jess O'Leary, product manager -
         <a href="mailto:jessica.o’leary@digital.cabinet-office.gov.uk">
           jessica.o’leary@digital.cabinet-office.gov.uk
         </a>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -127,8 +127,8 @@ title: Support
         </a>
         <br />
         Jess O'Leary, product manager -
-        <a href="mailto:jessica.o’leary@digital.cabinet-office.gov.uk">
-          jessica.o’leary@digital.cabinet-office.gov.uk
+        <a href="mailto:jessica.oleary@digital.cabinet-office.gov.uk">
+          jessica.oleary@digital.cabinet-office.gov.uk
         </a>
       </p>
 


### PR DESCRIPTION
Jess's email address had an incorrect apostrophe, this is the fix.