### PR TITLE
Update the services live on PaaS

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -67,7 +67,7 @@ title:
             <li>is built on an open source platform (<a href="https://www.cloudfoundry.org/">Cloud Foundry</a>) and deployed to a public cloud</li>
             <li>is flexible since applications aren’t locked into one cloud provider</li>
         </ul>
-        <p class="content-section__body">GOV.UK PaaS is already being used by the GOV.UK Trade Tariff live service, as well as several services building prototypes.</p>
+        <p class="content-section__body">GOV.UK PaaS is already being used by the GOV.UK Trade Tariff, GOV.UK Notify and GOV.UK Digital Marketplace live services, as well as several services building prototypes.</p>
         <p class="content-section__body"><a href="/features.html">Find out more about GOV.UK PaaS</a>. This includes how it’s built, run and supported, as well as how to use it.</p>
       </section>
 


### PR DESCRIPTION
##What

Updated content to show live services on PaaS are Trade Tariff, Notify and Digital Marketplace.

##Why

So our product pages are up to date.

##Who can review

Anyone but me