### PR TITLE
[#147125641] Add status page info to support page

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -104,7 +104,7 @@ title: Support
       <p>
         To contact us about a critical issue outside of working hours, please
         use the emergency email address you have been given. This will raise a
-        high priority alert and could wake us up in the middle of the night, so
+        high priority ticket which could alert us during the night, so
         it should only be used for critical incidents.
       </p>
 
@@ -140,7 +140,7 @@ title: Support
         Outside of working hours, please use the escalation contact
         details you have been sent.</p>
 
-        <h2 class="heading-large">Keep up to date</h2>
+        <h2 class="heading-large">Keeping up to date</h2>
 
         <p>
         Our <a href="https://status.cloud.service.gov.uk/">system status page</a>
@@ -149,7 +149,7 @@ title: Support
       </p>
 
       <p>
-        Join our <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">announcements mailing list</a>
+        <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a>
         to find out about new features and changes to the platform. If you have
         trouble signing up, please contact
         gov-uk-paas-support@digital.cabinet-office.gov.uk and we will add you

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -152,7 +152,7 @@ title: Support
         <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a>
         to find out about new features and changes to the platform. If you have
         trouble signing up, please contact
-        gov-uk-paas-support@digital.cabinet-office.gov.uk and we will add you
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> and we will add you
         manually.
         <p>
 

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -32,12 +32,17 @@ title: Support
         or ask for help.
       </p>
 
+      <p>
+        You can view the availability and database connectivity of live
+        applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>.
+      </p>
+      
+
       <h2 class="heading-large">Support during working hours</h2>
 
       <p>
-        Our office hours are 9am - 5pm Monday to Friday. During this time we
-        support:
-      </p>
+        Our office hours are 9am - 5pm Monday to Friday. During this time we support:
+
 
       <ul>
         <li>requests for help using GOV.UK PaaS</li>
@@ -90,18 +95,17 @@ title: Support
       <h2 class="heading-large">Contacting us about a critical issue</h2>
 
       <p>
-        To contact us about a critical issue during working hours, please use
-        our support email address,
+        To contact us during working hours, use our support email address,
         <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
           gov-uk-paas-support@digital.cabinet-office.gov.uk
         </a>.
       </p>
 
       <p>
-        To contact us outside of working hours, please use the emergency email
-        address you have been given. This will raise a high priority alert and
-        could wake us up in the middle of the night, so it should only be used
-        for critical incidents.
+        To contact us about a critical issue outside of working hours, please
+        use the emergency email address you have been given. This will raise a
+        high priority alert and could wake us up in the middle of the night, so
+        it should only be used for critical incidents.
       </p>
 
       <p>
@@ -134,7 +138,24 @@ title: Support
 
       <p>
         Outside of working hours, please use the escalation contact
-        details you have been sent.
+        details you have been sent.</p>
+
+        <h2 class="heading-large">Keep up to date</h2>
+
+        <p>
+        Our <a href="https://status.cloud.service.gov.uk/">system status page</a>
+        shows if live applications and databases are available. You can use this
+        page to sign up to get alerts and incident updates.
+      </p>
+
+      <p>
+        Join our <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">announcements mailing list</a>
+        to find out about new features and changes to the platform. If you have
+        trouble signing up, please contact
+        gov-uk-paas-support@digital.cabinet-office.gov.uk and we will add you
+        manually.
+        <p>
+
       </p>
     </div>
   </div>


### PR DESCRIPTION
## what

Added link to status page in first paragraph and a 'how to keep up to date' section at the bottom. Review comments from Jonathan Glassman are incorporated into the 2nd commit - it's this one that needs to be approved and merged. 

## who can approve

Anyone except me.