### PR TITLE
Fix product page deployment

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "govuk_template": "git://github.com/alphagov/govuk_template.git#^0.19.2",
     "govuk_frontend_toolkit": "git://github.com/alphagov/govuk_frontend_toolkit#v5.0.2",
-    "govuk_elements": "git://github.com/alphagov/govuk_elements"
+    "govuk_elements": "git://github.com/alphagov/govuk_elements#3.0.2"
   }
 }


### PR DESCRIPTION
## What

Pin the version of govuk_elements used in order to fix our deployment.

The deployment was failing due to missing files from the build step:

`Could not push new version - Error processing app files: lstat /tmp/build/dc867c03/files-to-push/build: no such file or directory`

`release/build` was failing with this error:

```
Run middleman...
bundler: failed to load command: middleman (/usr/local/bundle/bin/middleman)
Sass::SyntaxError: File to import not found or unreadable: govuk_elements/public/sass/elements/helpers.
Load paths:
  /tmp/build/80754af9/paas-product-page/components
  /tmp/build/80754af9/paas-product-page/source/javascripts
```

The version of alphagov/govuk_elements used in the last successful deployment was 3.0.2 and the version used in the failing deployment was 3.1.0.

The build script worked in my existing local repository, however failed in a freshly cloned one, which is equivalent to the environment that the deployment runs in. Pinning govuk_elements to 3.0.2 fixes the build script in a freshly cloned repo.

I have raised alphagov/product-page-example#39 to request that upstream is fixed.  alphagov/product-page-example#38 exists for the fixes required to make master work with recent versions of govuk_elements

## How to review

- Make a fresh checkout of this repo: `git clone git@github.com:alphagov/paas-product-page.git paas-product-page-new`
- run build script: `cd paas-product-page-new && git checkout fix_govuk_elements_breakage && ./release/build`

## Who can review 

Anyone but @bleach