### PR TITLE
Add SLAs to public docs

### DIFF
--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -18,6 +18,7 @@
 @import "govuk_elements/public/sass/elements/forms";
 @import "govuk_elements/public/sass/elements/layout";
 @import "govuk_elements/public/sass/elements/panels";
+@import "govuk_elements/public/sass/elements/tables";
 
 @import "govuk_template/source/assets/stylesheets/styleguide/colours";
 @import "govuk_template/source/assets/stylesheets/accessibility";

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -34,9 +34,9 @@ title: Support
 
       <p>
         You can view the availability and database connectivity of live
-        applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>.
+        applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>. Information on <a href="#raise-critical-incident">raising critical incidents</a> is below.
       </p>
-      
+
 
       <h2 class="heading-large">Support during working hours</h2>
 
@@ -92,7 +92,7 @@ title: Support
         the next working day.
       </p>
 
-      <h2 class="heading-large">Contacting us about a critical issue</h2>
+      <a name="raise-critical-incident"></a><h2 class="heading-large">Contacting us about a critical issue</h2>
 
       <p>
         To contact us during working hours, use our support email address,

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -28,17 +28,19 @@ title: Support
 
       <p>
         On this page you can find out about the support we provide during and
-        outside of working hours, and how you can contact us to report a problem
+        outside of working hours, our <a href="SLAs">production SLAs</a>, and how you can contact us to report a problem
         or ask for help.
       </p>
 
       <p>
-        You can view the availability and database connectivity of live
-        applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>. Information on <a href="#raise-critical-incident">raising critical incidents</a> is below.
+        Information on <a href="#raise-critical-incident">raising critical incidents</a> is below. You can also use our <a href="https://status.cloud.service.gov.uk/">system status page</a> to view the availability and database connectivity of live applications on GOV.UK PaaS.
       </p>
 
       <p>
-        Tenants are supported differently depending on whether they are in production, and if the request occurs during core hours. For example, only tenants on paid plans who are in production can raise out-of-hours incidents.</p>
+        Service teams are supported differently depending on whether they are in production, and if the request occurs during core hours. For example, only service teams on paid plans who are running services in production can raise out-of-hours incidents.
+      </p>
+      <p>
+        We often refer to our users - service teams - as "tenants" to avoid confusion with end users.
       </p>
 
       <h2 class="heading-large">Support during working hours</h2>
@@ -46,11 +48,11 @@ title: Support
       <p>
         Our office hours are 9am - 5pm Monday to Friday. During this time we support:
 
-
       <ul>
         <li>requests for help using GOV.UK PaaS</li>
         <li>fixing issues and resolving incidents</li>
       </ul>
+      </p>
 
       <p>
         We prioritise support for live services over those in development, and
@@ -95,7 +97,7 @@ title: Support
         the next working day.
       </p>
 
-      <h2 class="heading-large">SLAs for production tenants</h2>
+      <a name="SLAs"></a><h2 class="heading-large">SLAs for production tenants</h2>
 
       <table>
         <tbody>
@@ -109,10 +111,10 @@ title: Support
           <th scope="row">P1<br/>Critical<br/>Incident</th>
           <td>
              <ul class="list list-bullet">
-               <li  class="font-xsmall">Apps no longer being served due to an issue with our platform</li>
+               <li  class="font-xsmall">Applications are unavailable to end users due to a problem with our platform</li>
                <li class="font-xsmall">Serious security breach on the platform</li>
-               <li class="font-xsmall">You are unable to push an emergency fix to an app due to the PaaS API not being available</li>
-               <li class="font-xsmall">Your live production app has a P1 issue which cannot be resolved without us</li>
+               <li class="font-xsmall">You can't make a critical fix to your production app due to the PaaS API not being available</li>
+               <li class="font-xsmall">Your live production app has a P1 issue which cannot be resolved without help from us</li>
              </ul>
           </td>
           <td>
@@ -129,10 +131,10 @@ title: Support
           <td>
             <ul>
               <li class="font-xsmall">Can&apos;t update/push apps due to platform issue</li>
-              <li class="font-xsmall">Upstream vulnerabilities</li>
-              <li class="font-xsmall">Elevated error rates</li>
-              <li class="font-xsmall">Complete component failure</li>
-              <li class="font-xsmall">Substantial degradation of service</li>
+              <li class="font-xsmall">Upstream vulnerabilities in GOV.UK PaaS components</li>
+              <li class="font-xsmall">Elevated error rates on the GOV.UK PaaS platform</li>
+              <li class="font-xsmall">Complete failure of a GOV.UK PaaS component</li>
+              <li class="font-xsmall">Substantial degradation of the GOV.UK PaaS service</li>
             </ul>
           </td>
           <td>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -23,58 +23,35 @@ title: Support
 
       <p>
         GOV.UK PaaS is supported 24 hours a day, seven days a week by the team
-        that builds it.
+        that builds it. Response times and resolutions vary depending on the service status.
       </p>
 
       <p>
-        On this page you can find out about the support we provide during and
-        outside of working hours, our <a href="#SLAs">production SLAs</a>, and how you can contact us to report a problem
-        or ask for help.
-      </p>
-
-      <p>
-        Information on <a href="#raise-critical-incident">raising critical incidents</a> is below. You can also use our <a href="https://status.cloud.service.gov.uk/">system status page</a> to view the availability and database connectivity of live applications on GOV.UK PaaS.
-      </p>
-
-      <p>
-        Service teams are supported differently depending on whether they are in production, and if the request occurs during core hours. For example, only service teams on paid plans who are running services in production can raise out-of-hours incidents.
-      </p>
-      <p>
-        We often refer to our users - service teams - as "tenants" to avoid confusion with end users.
+        You can view the availability and database connectivity of live applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>.
       </p>
 
       <h2 class="heading-large">Support during working hours</h2>
 
       <p>
-        Our office hours are 9am - 5pm Monday to Friday. During this time we support:
+        Our office hours are 9am - 5pm Monday to Friday. You can email us at
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to:
 
       <ul>
-        <li>requests for help using GOV.UK PaaS</li>
-        <li>fixing issues and resolving incidents</li>
+        <li>report issues and incidents</li>
+        <li>get help using GOV.UK PaaS</li>
       </ul>
       </p>
 
       <p>
-        We prioritise support for live services over those in development, and
-        fixing issues with the platform over answering user queries. For more
-        information on how we respond to requests, you can look at our platform
-        documentation.
-      </p>
-
-      <p>
-        For help using GOV.UK PaaS or to report a problem with your service,
-        email us at
-        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
-          gov-uk-paas-support@digital.cabinet-office.gov.uk
-        </a>.
+        We prioritise fixing issues with the platform over answering user queries, and support for live services over support for services in development.
+        For more information on how we respond to requests, you can look at our <a href="https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas">technical documentation</a>.
       </p>
 
       <h2 class="heading-large">Support outside of working hours</h2>
 
       <p>
-        Between 5pm and 9am Monday to Friday, at weekends, and during Bank
-        Holidays we provide emergency support for critical incidents affecting
-        live production services. A critical incident is where:
+        Between 5pm and 9am on Monday to Friday, at weekends and during Bank Holidays we provide emergency support for critical incidents affecting live production services.
+        A critical incident is where:
       </p>
 
       <ul>
@@ -97,7 +74,16 @@ title: Support
         the next working day.
       </p>
 
-      <a name="SLAs"></a><h2 class="heading-large">SLAs for production tenants</h2>
+      To contact us about a crictical issue outside of working hours, please use the emergency email address you have been given.
+      This will raise a high priority ticket which could alert us during the night, so it should only be used for critical P1 incidents.
+      Please do not sure this email address with people outside of your team.
+      <p>
+
+      <h2 class="heading-large">Response and resolution times for services in production</h2>
+
+      <p>
+        We address incidents, issues and requests within the timeframes detailed below:
+      </p>
 
       <table>
         <tbody>
@@ -148,7 +134,7 @@ title: Support
         <tr>
           <th scope="row">P3<br/>Significant<br/>issue</th>
           <td>
-            <ul><li class="font-xsmall">Users (tenants or end users) experiencing intermittent or degraded service due to platform issue.</li></ul>
+            <ul><li class="font-xsmall">Users (platform users or end users) experiencing intermittent or degraded service due to platform issue.</li></ul>
           </td>
           <td>
             <p class="font-xsmall">Start work &amp; respond: 2 hours</p>
@@ -174,36 +160,16 @@ title: Support
       </tbody>
       </table>
 
-      <a name="raise-critical-incident"></a><h2 class="heading-large">Contacting us about a critical issue</h2>
-
-      <p>
-        To contact us during working hours, use our support email address,
-        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
-          gov-uk-paas-support@digital.cabinet-office.gov.uk
-        </a>.
-      </p>
-
-      <p>
-        To contact us about a critical issue outside of working hours, please
-        use the emergency email address you have been given. This will raise a
-        high priority ticket which could alert us during the night, so
-        it should only be used for critical incidents.
-      </p>
-
       <p>
         Please do not share this email address with people outside of your
         team.
       </p>
 
-      <h2 class="heading-large">How to escalate support requests</h2>
+      <h2 class="heading-large">Escalate support requests</h2>
 
       <p>
         If we are not handling your request for support in the way you would
-        expect, here is how to contact us.
-      </p>
-
-      <p>
-        During working hours, please contact a member of the product team:
+        expect, please contact a member of the product team, who will reply during working hours:
       </p>
 
       <p>
@@ -222,7 +188,7 @@ title: Support
         Outside of working hours, please use the escalation contact
         details you have been sent.</p>
 
-        <h2 class="heading-large">Keeping up to date</h2>
+        <h2 class="heading-large">Updates and announcements</h2>
 
         <p>
         Our <a href="https://status.cloud.service.gov.uk/">system status page</a>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -28,7 +28,7 @@ title: Support
 
       <p>
         On this page you can find out about the support we provide during and
-        outside of working hours, our <a href="SLAs">production SLAs</a>, and how you can contact us to report a problem
+        outside of working hours, our <a href="#SLAs">production SLAs</a>, and how you can contact us to report a problem
         or ask for help.
       </p>
 

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -37,6 +37,9 @@ title: Support
         applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>. Information on <a href="#raise-critical-incident">raising critical incidents</a> is below.
       </p>
 
+      <p>
+        Tenants are supported differently depending on whether they are in production, and if the request occurs during core hours. For example, only tenants on paid plans who are in production can raise out-of-hours incidents.</p>
+      </p>
 
       <h2 class="heading-large">Support during working hours</h2>
 
@@ -91,6 +94,83 @@ title: Support
         let you know. We’ll address anything that is not a critical incident
         the next working day.
       </p>
+
+      <h2 class="heading-large">SLAs for production tenants</h2>
+
+      <table>
+        <tbody>
+          <tr>
+          <th>Classification</th>
+          <th>Example</th>
+          <th>In hours</th>
+          <th>Out of hours</th>
+        </tr>
+        <tr>
+          <th scope="row">P1<br/>Critical<br/>Incident</th>
+          <td>
+             <ul class="list list-bullet">
+               <li  class="font-xsmall">Apps no longer being served due to an issue with our platform</li>
+               <li class="font-xsmall">Serious security breach on the platform</li>
+               <li class="font-xsmall">You are unable to push an emergency fix to an app due to the PaaS API not being available</li>
+               <li class="font-xsmall">Your live production app has a P1 issue which cannot be resolved without us</li>
+             </ul>
+          </td>
+          <td>
+            <p class="font-xsmall">Start work &amp; respond: 20 minutes</p>
+            <p class="font-xsmall">Update time: 1hr</p>
+          </td>
+          <td>
+            <p class="font-xsmall">Start work &amp; respond: 40 minutes</p>
+            <p class="font-xsmall">Update time: 1hr</p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">P2<br/>Major<br/>Incident</th>
+          <td>
+            <ul>
+              <li class="font-xsmall">Can&apos;t update/push apps due to platform issue</li>
+              <li class="font-xsmall">Upstream vulnerabilities</li>
+              <li class="font-xsmall">Elevated error rates</li>
+              <li class="font-xsmall">Complete component failure</li>
+              <li class="font-xsmall">Substantial degradation of service</li>
+            </ul>
+          </td>
+          <td>
+            <p class="font-xsmall">Start work &amp; respond: 30 minutes</p>
+            <p class="font-xsmall">Update time: 2hr</p>
+          </td>
+          <td>
+            <p class="font-xsmall"></p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">P3<br/>Significant<br/>issue</th>
+          <td>
+            <ul><li class="font-xsmall">Users (tenants or end users) experiencing intermittent or degraded service due to platform issue.</li></ul>
+          </td>
+          <td>
+            <p class="font-xsmall">Start work &amp; respond: 2 hours</p>
+            <p class="font-xsmall">Update time: 4 hours</p>
+          </td>
+          <td>
+            <p class="font-xsmall"></p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">P4<br/>Minor<br/>issue</th>
+          <td>
+            <ul><li class="font-xsmall">Component failure that is not immediately impacting on service</li></ul>
+          </td>
+          <td>
+            <p class="font-xsmall">Start work &amp; respond: 1 business day</p>
+            <p class="font-xsmall">Update time: 2 business days</p>
+          </td>
+          <td>
+            <p class="font-xsmall"></p>
+          </td>
+        </tr>
+      </tbody>
+      </table>
 
       <a name="raise-critical-incident"></a><h2 class="heading-large">Contacting us about a critical issue</h2>
 


### PR DESCRIPTION
Added more visible SLAs and signposting for critical incidents to the page, following misleading comments in the press that GaaP don’t have SLAs.

Add in-page links.

P3/P4 Incidents described as “issues”. SLAs identified as for
production tenants only.

Urmi and Jonathan to review.