### PR TITLE
Add onboarding journey to product page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -52,7 +52,7 @@ title:
           <li>rapidly scale applications</li>
           <li>easily manage applications</li>
           <li>get 24-hour platform-level support</li>
-          <li>get started easily with a free plan and services</li>
+          <li><a href="/onboarding.html">get started easily</a> with a free plan and services</li>
           <li>grow their service from prototype to production without replatforming</li>
           <li>take advantage of a pre-accredited hosting platform</li>
         </ul>
@@ -76,7 +76,7 @@ title:
             <li>is flexible since applications aren’t locked into one cloud provider</li>
         </ul>
         <p class="content-section__body">GOV.UK PaaS is already being used by the GOV.UK Trade Tariff, GOV.UK Notify and GOV.UK Digital Marketplace live services. Many other beta and prototype services across government are currently building on PaaS and will launch soon.</p>
-        <p class="content-section__body"><a href="/features.html">Find out more about GOV.UK PaaS</a>. This includes how it’s built, run and supported, as well as how to use it.</p>
+        <p class="content-section__body"><a href="/features.html">Find out more about GOV.UK PaaS features</a>. This includes how it’s built, run and supported, as well as how to use it. We&apos;ve also described the full lifecycle of <a href="onboarding.html">onboarding and building a new service with GOV.UK PaaS</a>.</p>
       </section>
 
       <section class="content-section content-section--with-top-border">

--- a/source/onboarding.html.erb
+++ b/source/onboarding.html.erb
@@ -1,0 +1,167 @@
+---
+title: Support
+---
+
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
+  <ol itemscope itemtype="http://schema.org/BreadcrumbList">
+    <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+    </li>
+    <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="/" itemprop="item"><span itemprop="name">GOV.UK PaaS</span></a>
+    </li>
+    <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="#main" itemprop="item"><span itemprop="name">Onboarding</span></a>
+    </li>
+  </ol>
+</nav>
+
+<div class="container">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge">GOV.UK PaaS onboarding</h1>
+
+      <p>
+        This sets out the typical journey for building a public-facing service with an in-house development team.
+        It assumes you&apos;re building according to the Digital Service Standard and the Service Manual.
+        If you&apos;re migrating an existing application, or working with suppliers there are additional factors to consider; we discuss these at the bottom.
+      </p>
+
+      <p>
+      <ol>
+
+        <li><b>Evaluate</b> your project’s needs against our features and product roadmap</li>
+        <li><a href="request-trial.html">Request a trial account</a> and set your password</li>
+        <li>Use <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">‘Getting Started’</a> guide to deploy a static site to test your connection</li>
+        <li>Read the orientation guide for your language to understand what PaaS already does for you</li>
+        <li>Push some sample code for your project:
+          <ul>
+            <li>Use the platform marketplace to request “trial plan” <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">services such as databases</a></li>
+            <li>Make any changes to your code to pick up configuration from environment variables rather than static config files (the “12 factor app” principles for cloud scalability)</li>
+            <li>Read our <a href="https://docs.cloud.service.gov.uk/#troubleshooting-2">troubleshooting documentation</a> to help you overcome any problems</li>
+            <li>Raise tickets with <a href="support.html">support</a> if needed</li>
+          </ul>
+        </li>
+        <li><b>Start using GOV.UK PaaS for team development</b> - request accounts for <a href="https://docs.cloud.service.gov.uk/#managing-users">additional team members with the appropriate roles</a></li>
+        <li>Start <a href="https://docs.cloud.service.gov.uk/#configuring-a-custom-continuous-integration-ci-system">using a CI service</a> such as Jenkins or Travis to run the app test/deploy pipeline</li>
+        <li>Continue to develop your code during trial period</li>
+        <li>By the end of trial period
+          <ul>
+            <li>Sign Memorandum of Understanding (MOU)</li>
+            <li>Move onto the appropriate paid tier given the needs of your service</li>
+            <li>Engage with your Information Security/Assurance colleagues to begin the process of accreditation; we can provide the PaaS documentation if they want to review it</li>
+          </ul>
+        </li>
+        <li><b>Build towards private beta</b> - <a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets">Set up ‘spaces’</a> for each of your service’s environments - integration, staging, production - and link them to your CI service</li>
+        <li>Configure each environment with the proper backing services; these are often small and open in integration, but high-availability and encrypted in production</li>
+        <li>Turn on <a href="https://docs.cloud.service.gov.uk/#scaling">extra instances</a> of key apps in production to get high availability</li>
+        <li>Continue development, trying out backing services and app ideas on a pay-as-you-go basis</li>
+        <li>Add user-provided services such as logging<a href="#asterisk">*</a>, file storage<a href="#asterisk">*</a>, antivirus etc.</li>
+        <li>Add features to integrate with any legacy APIs</li>
+        <li>Procure a monitoring and alerting solution<a href="#asterisk">*</a> and add key metrics; these will be specific to your application and can’t be provided by the platform automatically</li>
+        <li><b>Enter private beta:</b>
+          <ul>
+            <li>Work with your SIRO to get authority to operate your service with small amounts of production data</li>
+            <li>Request a trial.service.gov.uk URL</li>
+            <li>Use the platform marketplace to <a href="https://docs.cloud.service.gov.uk/#using-a-custom-domain">turn on a CDN using your trial domain name</a></li>
+            <li>Move to an appropriate paid platform support plan</li>
+            <li>Iterate your application support model</li>
+          </ul>
+        </li>
+        <li>Iterate your service during private beta, based on real user feedback and any incidents</li>
+        <li>Your accreditor should want you to arrange penetration testing at various stages throughout development; always give us a week’s notice of this</li>
+        <li>Reconfigure or add new backing services as needed</li>
+        <li>After your beta service assessment:
+          <ul>
+            <li>change your support plan</li>
+            <li>request a new service.gov.uk URL and re-configure the CDN</li>
+          </ul>
+        </li>
+        <li><b>Enter the public beta phase with your service</b></li>
+        <li>Continue to iterate your service based on user feedback and production needs, adding other services (e.g. autoscaling) where needed</li>
+        <li>Pass final assessment and go live</li>
+      </ol>
+      <p>
+        <a name="asterisk"></a>* These services may be available through the PaaS platform in the future rather than as separate procurements; please see our roadmap for more information
+      </p>
+
+      <h2 class="heading-large">Suppliers developing on GOV.UK PaaS</h2>
+
+      <p>
+        Services must always be owned by a civil servant who will take responsibility for the supplier&apos;s usage and spend.
+        They can request accounts for supplier team members, and can delegate further account creation where appropriate.
+        If you are a supplier wanting to do speculative investigation on GOV.UK PaaS please raise a support ticket and our engagement team will contact you.
+      </p>
+
+
+      <h2 class="heading-large">Migrating an existing service to GOV.UK PaaS</h2>
+
+      <p>
+        To contact us during working hours, use our support email address,
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+          gov-uk-paas-support@digital.cabinet-office.gov.uk
+        </a>.
+      </p>
+
+      <p>
+        An existing service will normally have made technology choices, and changing these will come with some switching costs.
+        Our roadmap shows the technologies we support, both now and in the future. Bear in mind that we are always looking for private beta partners for new features, which may align with your development cycle.
+      </p>
+
+      <p>
+        There may be some work involved in making your applications follow the 12-factor app principles, or
+        separating out a monolithic service into components.
+      </p>
+
+      <p>
+        Some issues may also only be visible when using production-scale data, and where necessary we may grant
+        short-term access to any paid services; however tenants will need to be careful if using production data.
+      </p>
+
+      <h2 class="heading-large">How to escalate support requests</h2>
+
+      <p>
+        If we are not handling your request for support in the way you would
+        expect, here is how to contact us.
+      </p>
+
+      <p>
+        During working hours, please contact a member of the product team:
+      </p>
+
+      <p>
+        Tom Dolan, senior product manager -
+        <a href="maitlo:tom.dolan@digital.cabinet-office-gov.uk">
+          tom.dolan@digital.cabinet-office-gov.uk
+        </a>
+        <br />
+        Jess O'Leary, product manager -
+        <a href="mailto:jessica.oleary@digital.cabinet-office.gov.uk">
+          jessica.oleary@digital.cabinet-office.gov.uk
+        </a>
+      </p>
+
+      <p>
+        Outside of working hours, please use the escalation contact
+        details you have been sent.</p>
+
+        <h2 class="heading-large">Keeping up to date</h2>
+
+        <p>
+        Our <a href="https://status.cloud.service.gov.uk/">system status page</a>
+        shows if live applications and databases are available. You can use this
+        page to sign up to get alerts and incident updates.
+      </p>
+
+      <p>
+        <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a>
+        to find out about new features and changes to the platform. If you have
+        trouble signing up, please contact
+        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> and we will add you
+        manually.
+        <p>
+
+      </p>
+    </div>
+  </div>
+</div>

--- a/source/onboarding.html.erb
+++ b/source/onboarding.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Support
+title: Onboarding to GOV.UK PaaS
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumbs">

--- a/source/onboarding.html.erb
+++ b/source/onboarding.html.erb
@@ -24,7 +24,7 @@ title: Support
       <p>
         This sets out the typical journey for building a public-facing service with an in-house development team.
         It assumes you&apos;re building according to the Digital Service Standard and the Service Manual.
-        If you&apos;re migrating an existing application, or working with suppliers there are additional factors to consider; we discuss these at the bottom.
+        If you&apos;re <a href="#migrating">migrating an existing application</a>, or <a href="#suppliers">working with suppliers</a> there are additional factors to consider; we discuss these at the bottom.
       </p>
 
       <p>
@@ -49,6 +49,7 @@ title: Support
           <ul>
             <li>Sign Memorandum of Understanding (MOU)</li>
             <li>Move onto the appropriate paid tier given the needs of your service</li>
+            <li>Work with Finance colleagues to set up billing arrangements</li>
             <li>Engage with your Information Security/Assurance colleagues to begin the process of accreditation; we can provide the PaaS documentation if they want to review it</li>
           </ul>
         </li>
@@ -85,7 +86,7 @@ title: Support
         <a name="asterisk"></a>* These services may be available through the PaaS platform in the future rather than as separate procurements; please see our roadmap for more information
       </p>
 
-      <h2 class="heading-large">Suppliers developing on GOV.UK PaaS</h2>
+      <a name="suppliers"></a><h2 class="heading-large">Suppliers developing on GOV.UK PaaS</h2>
 
       <p>
         Services must always be owned by a civil servant who will take responsibility for the supplier&apos;s usage and spend.
@@ -94,7 +95,7 @@ title: Support
       </p>
 
 
-      <h2 class="heading-large">Migrating an existing service to GOV.UK PaaS</h2>
+      <a name="migrating"></a><h2 class="heading-large">Migrating an existing service to GOV.UK PaaS</h2>
 
       <p>
         To contact us during working hours, use our support email address,
@@ -118,50 +119,6 @@ title: Support
         short-term access to any paid services; however tenants will need to be careful if using production data.
       </p>
 
-      <h2 class="heading-large">How to escalate support requests</h2>
-
-      <p>
-        If we are not handling your request for support in the way you would
-        expect, here is how to contact us.
-      </p>
-
-      <p>
-        During working hours, please contact a member of the product team:
-      </p>
-
-      <p>
-        Tom Dolan, senior product manager -
-        <a href="maitlo:tom.dolan@digital.cabinet-office-gov.uk">
-          tom.dolan@digital.cabinet-office-gov.uk
-        </a>
-        <br />
-        Jess O'Leary, product manager -
-        <a href="mailto:jessica.oleary@digital.cabinet-office.gov.uk">
-          jessica.oleary@digital.cabinet-office.gov.uk
-        </a>
-      </p>
-
-      <p>
-        Outside of working hours, please use the escalation contact
-        details you have been sent.</p>
-
-        <h2 class="heading-large">Keeping up to date</h2>
-
-        <p>
-        Our <a href="https://status.cloud.service.gov.uk/">system status page</a>
-        shows if live applications and databases are available. You can use this
-        page to sign up to get alerts and incident updates.
-      </p>
-
-      <p>
-        <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a>
-        to find out about new features and changes to the platform. If you have
-        trouble signing up, please contact
-        <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> and we will add you
-        manually.
-        <p>
-
-      </p>
     </div>
   </div>
 </div>

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -39,7 +39,7 @@ title: Roadmap
 
       <p>If you would like to find out more about these plans, or you have feedback on whether or not these features are useful for you, please <a href="/support.html">get in touch</a>. We are also keen for private beta partners on forthcoming features.</p>
 
-      <p>You can also <a href="/features.html">what GOV.UK PaaS offers right now</a>, or walk through a full <a href="/onboarding.html">onboarding and development journey</a>.</p>
+      <p>You can also see <a href="/features.html">what GOV.UK PaaS offers right now</a>, or walk through a full <a href="/onboarding.html">onboarding and development journey</a>.</p>
 
       <h2 class="heading-large">Roadmap</h2>
       <div class="panel panel-border-wide">

--- a/source/roadmap.html.erb
+++ b/source/roadmap.html.erb
@@ -39,7 +39,7 @@ title: Roadmap
 
       <p>If you would like to find out more about these plans, or you have feedback on whether or not these features are useful for you, please <a href="/support.html">get in touch</a>. We are also keen for private beta partners on forthcoming features.</p>
 
-      <p>To see what GOV.UK PaaS offers right now, visit <a href="/">our product page</a>.</p>
+      <p>You can also <a href="/features.html">what GOV.UK PaaS offers right now</a>, or walk through a full <a href="/onboarding.html">onboarding and development journey</a>.</p>
 
       <h2 class="heading-large">Roadmap</h2>
       <div class="panel panel-border-wide">


### PR DESCRIPTION
- Add on boarding page
- Add some links out to relevant bits of docs
- Add some inbound links
- Change roadmap page to direct “what it does now” users straight to
features, not via homepage.