### PR TITLE
Improve onboarding layout

### DIFF
--- a/source/onboarding.html.erb
+++ b/source/onboarding.html.erb
@@ -27,61 +27,96 @@ title: Onboarding to GOV.UK PaaS
         If you&apos;re <a href="#migrating">migrating an existing application</a>, or <a href="#suppliers">working with suppliers</a> there are additional factors to consider; we discuss these at the bottom.
       </p>
 
-      <p>
-      <ol>
+      <h2>1. Initial evaluation</h2>
 
-        <li><b>Evaluate</b> your project’s needs against our features and product roadmap</li>
+      <p>
+      <ul>
+
+        <li>Check your project’s needs against our <a href="/features.html">current features</a> and <a href="/roadmap.html">product roadmap</a></li>
         <li><a href="request-trial.html">Request a trial account</a> and set your password</li>
         <li>Use <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">‘Getting Started’</a> guide to deploy a static site to test your connection</li>
         <li>Read the orientation guide for your language to understand what PaaS already does for you</li>
         <li>Push some sample code for your project:
           <ul>
             <li>Use the platform marketplace to request “trial plan” <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">services such as databases</a></li>
-            <li>Make any changes to your code to pick up configuration from environment variables rather than static config files (the “12 factor app” principles for cloud scalability)</li>
+            <li>Bind the services to your apps with the command line, then get your app to look at environment variables so it can <a href="https://docs.cloud.service.gov.uk/#accessing-the-service-from-your-app">connect to the services</a>.</li>
+            <li>Make any other similar changes to your code to fit with the “12 factor app” principles for cloud scalability</li>
             <li>Read our <a href="https://docs.cloud.service.gov.uk/#troubleshooting-2">troubleshooting documentation</a> to help you overcome any problems</li>
             <li>Raise tickets with <a href="support.html">support</a> if needed</li>
           </ul>
         </li>
-        <li><b>Start using GOV.UK PaaS for team development</b> - request accounts for <a href="https://docs.cloud.service.gov.uk/#managing-users">additional team members with the appropriate roles</a></li>
+      </ul>
+    </p>
+    <h2>2. Collaborate with your team on the platform</h2>
+    <p>
+      <ul>
+        <li>Request accounts for <a href="https://docs.cloud.service.gov.uk/#managing-users">additional team members with the appropriate roles</a></li>
         <li>Start <a href="https://docs.cloud.service.gov.uk/#configuring-a-custom-continuous-integration-ci-system">using a CI service</a> such as Jenkins or Travis to run the app test/deploy pipeline</li>
         <li>Continue to develop your code during trial period</li>
-        <li>By the end of trial period
-          <ul>
-            <li>Sign Memorandum of Understanding (MOU)</li>
-            <li>Move onto the appropriate paid tier given the needs of your service</li>
-            <li>Work with Finance colleagues to set up billing arrangements</li>
-            <li>Engage with your Information Security/Assurance colleagues to begin the process of accreditation; we can provide the PaaS documentation if they want to review it</li>
-          </ul>
-        </li>
-        <li><b>Build towards private beta</b> - <a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets">Set up ‘spaces’</a> for each of your service’s environments - integration, staging, production - and link them to your CI service</li>
+      </ul>
+    </p>
+    <h2>3. By the end of the trial period</h2>
+    <p>
+      <ul>
+        <li>Sign Memorandum of Understanding (MOU)</li>
+        <li>Move onto the appropriate paid tier given the needs of your service</li>
+        <li>Work with Finance colleagues to set up billing arrangements</li>
+        <li>Engage with your Information Security/Assurance colleagues to begin the process of accreditation; we can provide the PaaS documentation if they want to review it</li>
+      </ul>
+    </p>
+    <h2>4. Build towards private beta</h2>
+    <p>
+      <ul>
+        <li><a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets">Set up ‘spaces’</a> for each of your service’s environments - integration, staging, production - and link them to your CI service</li>
         <li>Configure each environment with the proper backing services; these are often small and open in integration, but high-availability and encrypted in production</li>
         <li>Turn on <a href="https://docs.cloud.service.gov.uk/#scaling">extra instances</a> of key apps in production to get high availability</li>
         <li>Continue development, trying out backing services and app ideas on a pay-as-you-go basis</li>
         <li>Add user-provided services such as logging<a href="#asterisk">*</a>, file storage<a href="#asterisk">*</a>, antivirus etc.</li>
         <li>Add features to integrate with any legacy APIs</li>
         <li>Procure a monitoring and alerting solution<a href="#asterisk">*</a> and add key metrics; these will be specific to your application and can’t be provided by the platform automatically</li>
-        <li><b>Enter private beta:</b>
-          <ul>
-            <li>Work with your SIRO to get authority to operate your service with small amounts of production data</li>
-            <li>Request a trial.service.gov.uk URL</li>
-            <li>Use the platform marketplace to <a href="https://docs.cloud.service.gov.uk/#using-a-custom-domain">turn on a CDN using your trial domain name</a></li>
-            <li>Move to an appropriate paid platform support plan</li>
-            <li>Iterate your application support model</li>
-          </ul>
-        </li>
+      </ul>
+    </p>
+    <h2>5. Enter private beta</h2>
+    <p>
+      <ul>
+        <li>Work with your SIRO to get authority to operate your service with small amounts of production data</li>
+        <li>Request a trial.service.gov.uk URL</li>
+        <li>Use the platform marketplace to <a href="https://docs.cloud.service.gov.uk/#using-a-custom-domain">turn on a CDN using your trial domain name</a></li>
+        <li>Move to an appropriate paid platform support plan</li>
+        <li>Iterate your application support model</li>
+      </ul>
+    </p>
+    <h2>6. During private beta</h2>
+    <p>
+      <ul>
         <li>Iterate your service during private beta, based on real user feedback and any incidents</li>
         <li>Your accreditor should want you to arrange penetration testing at various stages throughout development; always give us a week’s notice of this</li>
         <li>Reconfigure or add new backing services as needed</li>
-        <li>After your beta service assessment:
-          <ul>
-            <li>change your support plan</li>
-            <li>request a new service.gov.uk URL and re-configure the CDN</li>
-          </ul>
-        </li>
-        <li><b>Enter the public beta phase with your service</b></li>
+      </ul>
+    </p>
+    <h2>7. After your beta service assessment</h2>
+    <p>
+      <ul>
+        <li>change your support plan</li>
+        <li>request a new service.gov.uk URL and re-configure the CDN</li>
+      </ul>
+    </p>
+    <h2>8. Enter the public beta phase with your service</h2>
+    <p>
+      <ul>
         <li>Continue to iterate your service based on user feedback and production needs, adding other services (e.g. autoscaling) where needed</li>
-        <li>Pass final assessment and go live</li>
-      </ol>
+        <li>Pass final assessment</li>
+      </ul>
+    </p>
+    <h2>9. After live assessment</h2>
+    <p>
+      <ul>
+        <li>Keep your dependencies up to date</li>
+        <li>Be ready to redeploy if there are vulnerabilities in language runtimes</li>
+      </ul>
+    </p>
+
+
       <p>
         <a name="asterisk"></a>* These services may be available through the PaaS platform in the future rather than as separate procurements; please see our roadmap for more information
       </p>


### PR DESCRIPTION
- h2 tags for major sections
- bullet points instead of numbered lists to make it feel less
relentless
- tidied up the ‘services’ bit as it was slightly wordy.
- added in that teams had responsibilities after live.