### PR TITLE
Use GOV.UK Elements bulleted list styles

### DIFF
--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -48,7 +48,7 @@ title: Features
             <li>Ruby</li>
         </ul>
       <p>or:</p>
-      <ul>
+      <ul class="list list-bullet">
             <li>a static HTML/CSS/Javascript site</li>
             <li>a compiled binary</li>
 

--- a/source/onboarding.html.erb
+++ b/source/onboarding.html.erb
@@ -30,14 +30,14 @@ title: Onboarding to GOV.UK PaaS
       <h2>1. Initial evaluation</h2>
 
       <p>
-      <ul>
+      <ul class="list list-bullet">
 
         <li>Check your project’s needs against our <a href="/features.html">current features</a> and <a href="/roadmap.html">product roadmap</a></li>
         <li><a href="request-trial.html">Request a trial account</a> and set your password</li>
         <li>Use <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">‘Getting Started’</a> guide to deploy a static site to test your connection</li>
         <li>Read the orientation guide for your language to understand what PaaS already does for you</li>
         <li>Push some sample code for your project:
-          <ul>
+          <ul class="list list-bullet">
             <li>Use the platform marketplace to request “trial plan” <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">services such as databases</a></li>
             <li>Bind the services to your apps with the command line, then get your app to look at environment variables so it can <a href="https://docs.cloud.service.gov.uk/#accessing-the-service-from-your-app">connect to the services</a>.</li>
             <li>Make any other similar changes to your code to fit with the “12 factor app” principles for cloud scalability</li>
@@ -49,7 +49,7 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>2. Collaborate with your team on the platform</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Request accounts for <a href="https://docs.cloud.service.gov.uk/#managing-users">additional team members with the appropriate roles</a></li>
         <li>Start <a href="https://docs.cloud.service.gov.uk/#configuring-a-custom-continuous-integration-ci-system">using a CI service</a> such as Jenkins or Travis to run the app test/deploy pipeline</li>
         <li>Continue to develop your code during trial period</li>
@@ -57,7 +57,7 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>3. By the end of the trial period</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Sign Memorandum of Understanding (MOU)</li>
         <li>Move onto the appropriate paid tier given the needs of your service</li>
         <li>Work with Finance colleagues to set up billing arrangements</li>
@@ -66,7 +66,7 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>4. Build towards private beta</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li><a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets">Set up ‘spaces’</a> for each of your service’s environments - integration, staging, production - and link them to your CI service</li>
         <li>Configure each environment with the proper backing services; these are often small and open in integration, but high-availability and encrypted in production</li>
         <li>Turn on <a href="https://docs.cloud.service.gov.uk/#scaling">extra instances</a> of key apps in production to get high availability</li>
@@ -78,7 +78,7 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>5. Enter private beta</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Work with your SIRO to get authority to operate your service with small amounts of production data</li>
         <li>Request a trial.service.gov.uk URL</li>
         <li>Use the platform marketplace to <a href="https://docs.cloud.service.gov.uk/#using-a-custom-domain">turn on a CDN using your trial domain name</a></li>
@@ -88,7 +88,7 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>6. During private beta</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Iterate your service during private beta, based on real user feedback and any incidents</li>
         <li>Your accreditor should want you to arrange penetration testing at various stages throughout development; always give us a week’s notice of this</li>
         <li>Reconfigure or add new backing services as needed</li>
@@ -96,21 +96,21 @@ title: Onboarding to GOV.UK PaaS
     </p>
     <h2>7. After your beta service assessment</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>change your support plan</li>
         <li>request a new service.gov.uk URL and re-configure the CDN</li>
       </ul>
     </p>
     <h2>8. Enter the public beta phase with your service</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Continue to iterate your service based on user feedback and production needs, adding other services (e.g. autoscaling) where needed</li>
         <li>Pass final assessment</li>
       </ul>
     </p>
     <h2>9. After live assessment</h2>
     <p>
-      <ul>
+      <ul class="list list-bullet">
         <li>Keep your dependencies up to date</li>
         <li>Be ready to redeploy if there are vulnerabilities in language runtimes</li>
       </ul>

--- a/source/request-trial.html.erb
+++ b/source/request-trial.html.erb
@@ -41,7 +41,7 @@ title: Trial Account
                 and tell us:
             </p>
 
-            <ul>
+            <ul class="list list-bullet">
                 <li>
                   the name of your department and service team (if applicable)
                 </li>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -17,6 +17,7 @@
 @import "govuk_elements/public/sass/elements/elements-typography";
 @import "govuk_elements/public/sass/elements/forms";
 @import "govuk_elements/public/sass/elements/layout";
+@import "govuk_elements/public/sass/elements/lists";
 @import "govuk_elements/public/sass/elements/panels";
 @import "govuk_elements/public/sass/elements/tables";
 

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -36,7 +36,7 @@ title: Support
         Our office hours are 9am - 5pm Monday to Friday. You can email us at
         <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to:
 
-      <ul>
+      <ul class="list list-bullet">
         <li>report issues and incidents</li>
         <li>get help using GOV.UK PaaS</li>
       </ul>
@@ -54,7 +54,7 @@ title: Support
         A critical incident is where:
       </p>
 
-      <ul>
+      <ul class="list list-bullet">
         <li>
           your application is unavailable due to a problem with our platform
         </li>
@@ -115,7 +115,7 @@ title: Support
         <tr>
           <th scope="row">P2<br/>Major<br/>Incident</th>
           <td>
-            <ul>
+            <ul class="list list-bullet">
               <li class="font-xsmall">Can&apos;t update/push apps due to platform issue</li>
               <li class="font-xsmall">Upstream vulnerabilities in GOV.UK PaaS components</li>
               <li class="font-xsmall">Elevated error rates on the GOV.UK PaaS platform</li>
@@ -134,7 +134,9 @@ title: Support
         <tr>
           <th scope="row">P3<br/>Significant<br/>issue</th>
           <td>
-            <ul><li class="font-xsmall">Users (platform users or end users) experiencing intermittent or degraded service due to platform issue.</li></ul>
+            <ul class="list list-bullet">
+              <li class="font-xsmall">Users (platform users or end users) experiencing intermittent or degraded service due to platform issue.</li>
+            </ul>
           </td>
           <td>
             <p class="font-xsmall">Start work &amp; respond: 2 hours</p>
@@ -147,7 +149,9 @@ title: Support
         <tr>
           <th scope="row">P4<br/>Minor<br/>issue</th>
           <td>
-            <ul><li class="font-xsmall">Component failure that is not immediately impacting on service</li></ul>
+            <ul class="list list-bullet">
+              <li class="font-xsmall">Component failure that is not immediately impacting on service</li>
+            </ul>
           </td>
           <td>
             <p class="font-xsmall">Start work &amp; respond: 1 business day</p>


### PR DESCRIPTION
The markup on the PaaS product page is styling lists with class names defined in GOV.UK elements<sup>1</sup>. However, the SASS file where GOV.UK Elements defines these class names<sup>2</sup> is not being imported.

This means that the bulleted lists on the PaaS product page are not getting the styling from GOV.UK elements, which means that:
- the lines are closer together (harder to read)
- the bullets are indented from the left edge of the text (so the page looks messier)

This commit imports the SASS from GOV.UK elements to make lists look better.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/29707061-d2af0120-897b-11e7-8677-d83937e087b1.png) | ![image](https://user-images.githubusercontent.com/355079/29707038-c12c7be4-897b-11e7-9e2e-86129742d072.png)

1. Example here: https://github.com/alphagov/paas-product-page/blob/8b9f68f25472145a5269a8d10a3894fef18eea7c/source/index.html.erb#L49
2. Source here: https://github.com/alphagov/govuk_elements/blob/dea6e7bbaf83ecc670bc2cd31539096fab542484/packages/govuk-elements-sass/public/sass/elements/_lists.scss#L20-L23

