### PR TITLE
Set Google Analytics tracker fields

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -29,6 +29,9 @@
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-43115970-5', 'auto');
+      ga('set', 'anonymizeIp', true);
+      ga('set', 'displayFeaturesTask', null);
+      ga('set', 'transport', 'beacon');
       ga('send', 'pageview');
     </script>
   </head>


### PR DESCRIPTION
Set the GA tracker to anonymise user IP addresses, disable display features and use the beacon transport mode.

Anonymise user IP addresses for all hits sent from the tracker:
https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization

Disable all display features functionality:
https://developers.google.com/analytics/devguides/collection/analyticsjs/display-features#disabling-display-features

To avoid missing hits in GA when a document unloads, set the tracker to use the Navigator.sendBeacon() transport mechanism when available. This will transmit hits to GA asynchronously when the User Agent has an opportunity to do so, without delaying the unload or affecting the performance of the next navigation. GA will fallback to XMLHttpRequest or Image transport mechanisms when navigator.sendBeacon isn't supported by the user's browser.

https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms