### PR TITLE
Remove private docker images from roadmap

### DIFF
--- a/views/features.erb
+++ b/views/features.erb
@@ -70,7 +70,7 @@
 				<li>Manage applications with the CloudFoundry command line or API</li>
 				<li>Scale applications up and downs in seconds</li>
 				<li>You can build on the API or the command line to enable auto-scaling</li>
-				<li>Deploy from Travis CI</li>
+				<li>Deploy from CI services such as Travis or Jenkins</li>
 				<li>Use a custom domain to host your app</li>
 			</ul>
 			<h2 class="heading-medium">Performance</h2>

--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -40,7 +40,6 @@
 				<li>RabbitMQ</li>
 				<li>Logging and monitoring – public beta</li>
 				<li>Billing portal</li>
-				<li>Private Docker images</li>
 				<li>VM isolation*</li>
 				<li>File storage</li>
 			</ul>


### PR DESCRIPTION
Private docker images now “come for free” with Cloud Foundry, so we don’t need to build this.