### PR TITLE
Remove duplication

### DIFF
--- a/views/support.erb
+++ b/views/support.erb
@@ -14,7 +14,6 @@
 			<p>You can view the availability and database connectivity of live applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>. If you have a critical issue, start by checking this page: if it’s an issue with GOV.UK PaaS we’re already working on it, and we’ll keep our users updated on the progression of the incident.</p>
 			<h2 class="heading-large">Support during working hours</h2>
 			<p>Our office hours are 9am - 5pm Monday to Friday. You can email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to:</p>
-			<p>Our office hours are 9am - 5pm Monday to Friday. You can email us at gov-uk-paas-support@digital.cabinet-office.gov.uk to:</p>
 			<ul class="list list-bullet">
 				<li>report issues and incidents</li>
 				<li>get help using GOV.UK PaaS</li>


### PR DESCRIPTION
## What

One of our tenants has reported a duplication on the support page. We're removing an extra paragraph in order to keep the page clean and tidy.

## How to review

- See if the change is suitable