### PR TITLE
Anonymise user IP and enable beacon features in GA

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,15 +25,15 @@ class App < Sinatra::Base
 
 	# Protection to limit potential XSS attacks and effects.
 	use Rack::Protection::ContentSecurityPolicy,
-		:default_src => 'none',
-		:script_src => '\'self\' www.google-analytics.com',
-		:style_src => '\'self\' \'unsafe-inline\'',
-		:img_src => '\'self\' www.google-analytics.com',
-		:connect_src => '\'self\'',
-		:frame_src => '\'self\'',
-		:font_src => '\'self\' data:',
-		:object_src => '\'self\'',
-		:media_src => '\'self\''
+		:default_src => "none",
+		:script_src => "'self' www.google-analytics.com",
+		:style_src => "'self' 'unsafe-inline'",
+		:img_src => "'self' www.google-analytics.com",
+		:connect_src => "'self' www.google-analytics.com",
+		:frame_src => "'self'",
+		:font_src => "'self' data:",
+		:object_src => "'self'",
+		:media_src => "'self'"
 
 	configure do
 		sprockets.append_path File.join(root, 'assets', 'stylesheets', 'govuk_frontend_toolkit')

--- a/assets/js/google-analytics.js
+++ b/assets/js/google-analytics.js
@@ -4,4 +4,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-43115970-5', 'auto');
+ga('set', 'anonymizeIp', true);
+ga('set', 'displayFeaturesTask', null);
+ga('set', 'transport', 'beacon');
 ga('send', 'pageview');

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "ContactUs", :type => :feature do
 	it "should provide the correct Content-Security-Policy" do
 		visit '/contact-us'
 		expect(page.status_code).to eq(200)
-		expect(page.response_headers['Content-Security-Policy']).to eq("connect-src 'self'; default-src none; font-src 'self' data:; frame-src 'self'; img-src 'self' www.google-analytics.com; media-src 'self'; object-src 'self'; script-src 'self' www.google-analytics.com; style-src 'self' 'unsafe-inline'")
+		expect(page.response_headers['Content-Security-Policy']).to eq("connect-src 'self' www.google-analytics.com; default-src none; font-src 'self' data:; frame-src 'self'; img-src 'self' www.google-analytics.com; media-src 'self'; object-src 'self'; script-src 'self' www.google-analytics.com; style-src 'self' 'unsafe-inline'")
 	end
 
 end


### PR DESCRIPTION
## What

* [Enables anonymising user IP addresses](https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization)
* [Disables all display features functionality](https://developers.google.com/analytics/devguides/collection/analyticsjs/display-features#disabling-display-features)
* [Enables beacon to avoid missing hits in GA when a document unloads](https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms)

**Note**: The "beacon" feature above requires a websocket connection to the google
analytics endpoint, and so the Content-Security-Policy was updated to
allow this.

## How to review

* Code review
* Run tests and server locally and check for an issues.

## Who can review

Not @chrisfarms 