### PR TITLE
[#152638275] Make sure the logo image used by the PaaS emails does exist

### DIFF
--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -1,0 +1,21 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'rack/test'
+require 'capybara/rspec'
+require 'net/http'
+Capybara.app = Rack::Builder.parse_file("config.ru").first
+
+RSpec.describe "Static assets", :type => :feature do
+
+	include Rack::Test::Methods
+
+	def app()
+		Rack::Builder.parse_file("config.ru").first
+	end
+
+	it "the logo image used by our PaaS emails should exist" do
+		get "images/gov.uk_logotype_crown.png"
+		expect(last_response.status).to eq(200)
+	end
+
+end


### PR DESCRIPTION
## What

We'll start to send HTML emails which will include the GOV.UK logo in the
header. We want to make sure we don't accidentally delete this header image, so
we add a test case to check if it still exists.

## How to review

Check if the new test is valid. Travis already runs the tests, so if the PR is green it's good to go.

## Who can review

Not @bandesz