### PR TITLE
Add primary contact org manager status

### DIFF
--- a/models/deskpro.rb
+++ b/models/deskpro.rb
@@ -90,6 +90,7 @@ module Deskpro
 		field :person_name,                  String, :required => true, :min => 2, :max => MAX_FIELD_LEN, :label => 'Name'
 		field :person_organization,          String
 		field :person_organization_position, String
+		field :person_is_manager,            Boolean
 		field :subject,                      String, :required => true, :max => MAX_FIELD_LEN, :min => 1
 		field :message,                      String, :required => true, :max => MAX_FIELD_LEN, :min => 1
 		field :message_as_agent,             Integer, :min => 0, :max => 1

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -26,7 +26,7 @@ module Forms
 				"New organisation/account signup request from website",
 				"",
 				"From: #{person_name}",
-				"Email: #{person_email}",
+				"Email: #{person_email} #{"(org manager)" if person_is_manager}",
 				"Department: #{department_name}",
 				"Team: #{service_name}",
 			].join("\n")
@@ -34,7 +34,7 @@ module Forms
 				msg << ([
 					"",
 					"They would also like to invite:",
-				] + invites.map{ |invite| "#{invite.person_email} (org manager: #{!!invite.person_is_manager})" }).join("\n")
+				] + invites.map{ |invite| "#{invite.person_email} #{"(org manager)" if invite.person_is_manager}" }).join("\n")
 			end
 			msg
 		end

--- a/spec/deskpro_spec.rb
+++ b/spec/deskpro_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Deskpro do
 			ticket = Deskpro::Ticket.new({
 				person_email: "test@localhost.local",
 				subject: "HELP",
+				person_is_manager: false,
 				message: "Please help me",
 				agent_team_id: 1,
 				message_as_agent: 1,
@@ -15,6 +16,7 @@ RSpec.describe Deskpro do
 			})
 			expect(ticket.person_email).to eq('test@localhost.local')
 			expect(ticket.subject).to eq('HELP')
+			expect(ticket.person_is_manager).to eq(false)
 			expect(ticket.message).to eq('Please help me')
 			expect(ticket.agent_team_id).to eq(1)
 			expect(ticket.message_as_agent).to eq(1)

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Signup", :type => :feature do
 		fill_in('person_email', with: 'jeff@test.gov.uk')
 		fill_in('department_name', with: 'TestDept')
 		fill_in('service_name', with: 'TestService')
+		find('input#person_is_manager-0.toggle-radio-note').set(true)
 		click_button('signup-submit')
 		all('.error-message').each do |err|
 			expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
@@ -100,6 +101,23 @@ RSpec.describe "Signup", :type => :feature do
 		click_button('signup-submit')
 		expect(page.first('.form-group--invites .error-message').text).not_to be_empty
 		expect(page.status_code).to eq(400)
+	end
+
+	it "should submit the form successfully when not an org manager" do
+		visit '/signup'
+		fill_in('person_name', with: 'Jeff Jefferson')
+		fill_in('person_email', with: 'jeff@test.gov.uk')
+		fill_in('department_name', with: 'TestDept')
+		fill_in('service_name', with: 'TestService')
+		find('input#person_is_manager-1.toggle-radio-note').set(true)
+		click_button('signup-submit')
+		all('.error-message').each do |err|
+			expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
+		end
+		all('.error-summary .err').each do |err|
+			expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
+		end
+		expect(page.status_code).to eq(200)
 	end
 
 end


### PR DESCRIPTION
## What

We have become aware that the org manager selection status is not passed through to the deskpro ticket. this PR fixes that by adding `(org manager: #{!!person_is_manager})` to the primary contact email address.

## How to review

- Code review 
- Run the application locally (`bundle install && make dev`) and test/see the changes

## Who can review

Not @LeePorte