### PR TITLE
Remove names of specific people who can review changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to paas-product-page
 
 Changes to the content of the product pages must be reviewed by someone from the GaaP
-Content Team (Sheryll Sulit or Tom Macavoy).
+Content Team.
 
 Changes to the deployment mechanism can be merged by the GOV.UK PaaS team.


### PR DESCRIPTION
We discussed this in Slack and decided it shouldn't be the case that specific people are mentioned as possible reviewers. People move around and this is likely to get out-of-date quickly.