### PR TITLE
[#153050309] Update onboarding page(s)

### DIFF
--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -9,6 +9,19 @@
 
 <div class="container">
 	<div class="grid-row">
+		<div class="column-one-third">
+			<nav class="sub-navigation">
+				<ol itemscope itemtype="http://schema.org/ItemList">
+					<li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="/get-started" itemprop="item"><span itemprop="name">Evaluate the platform</span></a>
+					</li>
+					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="/migrate-live-services" itemprop="item"><span itemprop="name">Migrate a live service to GOV.UK PaaS</span></a>
+					</li>
+				</ol>
+			</nav>
+		</div>
+
 		<div class="column-two-thirds">
 			<h1 class="heading-xlarge">Get started with GOV.UK PaaS</h1>
 			<h2 class="heading-large">Evaluate GOV.UK PaaS</h2>

--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -1,6 +1,6 @@
 
 <% content_for :head do %>
-	<title>Onboarding to GOV.UK PaaS - <%= settings.title %></title>
+	<title>Get started with GOV.UK PaaS - <%= settings.title %></title>
 <% end %>
 
 <% content_for :breadcrumb do %>
@@ -10,111 +10,40 @@
 <div class="container">
 	<div class="grid-row">
 		<div class="column-two-thirds">
-			<h1 class="heading-xlarge">Get started</h1>
+			<h1 class="heading-xlarge">Get started with GOV.UK PaaS</h1>
+			<h2 class="heading-large">Evaluate GOV.UK PaaS</h2>
 			<p>
-				This is a typical journey for building a public-facing service with an in-house development team.
-				It assumes you&apos;re building according to the <a href="https://www.gov.uk/service-manual/service-standard">Digital Service Standard</a> and the <a href="https://www.gov.uk/service-manual">Service Manual</a>.
-			</p>
-		</div>
-	</div>
-	<div class="grid-row">
-		<div class="column-two-thirds">
-
-			<h2 class="task-list-section"><span class="task-list-section-number">1.</span> Check GOV.UK PaaS is right for you</h2>
-			<div class="task-list-items">
-				<p>Check your project’s needs against our <a href="/features">current features</a> and <a href="/roadmap">product roadmap</a>.</p>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">2.</span> Get a trial account</h2>
-			<div class="task-list-items">
-				<p><a href="/signup">Request an account</a> and add other team members, if appropriate.</p>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">3.</span> Test using the platform</h2>
-			<div class="task-list-items">
-				<p>Work through the <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">‘Quick Setup Guide’</a> to deploy your first static site to test your connection. Read the orientation guide for your language to understand what PaaS already does for you.</p>
-				<p>Push some sample code for your project:</p>
-				<ul class="list list-bullet">
-					<li>Use the platform marketplace to request “trial plan” <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">services such as databases</a></li>
-					<li>Bind the services to your apps with the command line, then get your app to look at environment variables so it can <a href="https://docs.cloud.service.gov.uk/#accessing-the-service-from-your-app">connect to the services</a>.</li>
-					<li>Make any other similar changes to your code to fit with the “12 factor app” principles for cloud scalability</li>
-					<li>Read our <a href="https://docs.cloud.service.gov.uk/#troubleshooting-2">troubleshooting documentation</a> to help you overcome any problems</li>
-					<li>Raise tickets with <a href="/support">support</a> if needed</li>
-				</ul>
-				<p>Consider <a href="https://docs.cloud.service.gov.uk/#configuring-a-custom-continuous-integration-ci-system">using a CI service</a> such as Jenkins or Travis to run the app test/deploy pipeline</p>
-			</div>
-
-
-			<h2 class="task-list-section"><span class="task-list-section-number">4.</span> Start preparing for going live</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Sign Memorandum of Understanding (MOU)</li>
-					<li>Move onto the appropriate paid tier given the needs of your service</li>
-					<li>Work with Finance colleagues to set up billing arrangements</li>
-					<li>Engage with your Information Security/Assurance colleagues to begin the process of accreditation; we can provide the PaaS documentation if they want to review it</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">5.</span> Build towards private beta</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li><a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets">Set up ‘spaces’</a> for each of your service’s environments - integration, staging, production - and link them to your CI service</li>
-					<li>Configure each environment with the proper backing services; these are often small and open in integration, but high-availability and encrypted in production</li>
-					<li>Turn on <a href="https://docs.cloud.service.gov.uk/#scaling">extra instances</a> of key apps in production to get high availability</li>
-					<li>Continue development, trying out backing services and app ideas on a pay-as-you-go basis</li>
-					<li>Add user-provided services such as logging<a href="#asterisk">*</a>, file storage<a href="#asterisk">*</a>, antivirus etc.</li>
-					<li>Add features to integrate with any legacy APIs</li>
-					<li>Procure a monitoring and alerting solution<a href="#asterisk">*</a> and add key metrics; these will be specific to your application and can’t be provided by the platform automatically</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">6.</span> Enter private beta</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Work with your SIRO to get authority to operate your service with small amounts of production data</li>
-					<li>Request a trial.service.gov.uk URL</li>
-					<li>Use the platform marketplace to <a href="https://docs.cloud.service.gov.uk/#using-a-custom-domain">turn on a CDN using your trial domain name</a></li>
-					<li>Move to an appropriate paid platform support plan</li>
-					<li>Iterate your application support model</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">7.</span> During private beta</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Iterate your service during private beta, based on real user feedback and any incidents</li>
-					<li>Your accreditor should want you to arrange penetration testing at various stages throughout development; always give us a week’s notice of this</li>
-					<li>Reconfigure or add new backing services as needed</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">8.</span> After your beta service assessment</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Change your support plan</li>
-					<li>Request a new service.gov.uk URL and re-configure the CDN</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">9.</span> Enter the public beta phase with your service</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Continue to iterate your service based on user feedback and production needs, adding other services (e.g. autoscaling) where needed</li>
-					<li>Pass final assessment</li>
-				</ul>
-			</div>
-
-			<h2 class="task-list-section"><span class="task-list-section-number">10.</span> After live assessment</h2>
-			<div class="task-list-items">
-				<ul class="list list-bullet">
-					<li>Keep your dependencies up to date</li>
-					<li>Be ready to redeploy if there are vulnerabilities in language runtimes</li>
-				</ul>
-			</div>
-			<p>
-				<a name="asterisk"></a>* These services may be available through the PaaS platform in the future rather than as separate procurements; please see our roadmap for more information.
+				If you’re considering cloud-based solutions for your web app, GOV.UK PaaS offers a trial period with a set of basic features and a capped <a href="https://docs.cloud.service.gov.uk/#quotas">quota</a> of compute and storage. Keep in mind that you can’t use the trial version of the platform for production or live services.
 			</p>
 
+			<h3 class="heading-medium">Check the features</h3>
+			<p>
+				Make sure we currently support the <a href="https://docs.cloud.service.gov.uk/#paas-requirements">language, framework</a> and <a href="/features">backing services</a> you need. Our <a href="/roadmap">roadmap</a> lists the features planned for release in the coming months.
+			</p>
+
+			<h3 class="heading-medium">Request a trial account</h3>
+			<p>
+				When you <a href="/signup">request an account</a> you can invite as many team members as you need and choose the ones who’ll be in charge of managing users. They’ll be able to request more user accounts, including ones for external suppliers, and assign <a href="https://docs.cloud.service.gov.uk/#user-roles">roles and permissions</a>.
+			</p>
+
+			<h3 class="heading-medium">Push your first app</h3>
+			<p>
+				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">quick setup guide</a> will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.
+			</p>
+
+			<h3 class="heading-medium">Support in trial mode</h3>
+			<p>
+				Check the documentation to <a href="https://docs.cloud.service.gov.uk/#troubleshooting">troubleshoot common problems</a>. If you can’t find a solution our team can help during office hours. Contact us through our <a href="/support">support page</a>.
+			</p>
+
+			<h3 class="heading-medium">Increase your quota</h3>
+			<p>
+				If you decide to increase your quota and make full use of the platform on a paid basis, get in contact with <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.<br />
+				Procurement starts with signing a Memorandum of Understanding. You might not need to do this if your department has already signed one.<br />
+				Finance colleagues will help setting up billing arrangements.
+			</p>
+
+			<a class="button" href="/signup">Request a trial account</a>
 		</div>
 	</div>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -48,7 +48,7 @@
 				<ul>
 					<% {
 						'About' => '/',
-						'Get Started' => '/get-started',
+						'Get started' => '/get-started',
 						'Features' => '/features',
 						'Documentation' => 'https://docs.cloud.service.gov.uk',
 						'Support' => '/support'

--- a/views/migrate-live-services.erb
+++ b/views/migrate-live-services.erb
@@ -1,0 +1,47 @@
+
+<% content_for :head do %>
+	<title>Migrate a live service to GOV.UK PaaS - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Get started', href: request.path_info, active: true} %>
+<% end %>
+
+<div class="container">
+	<div class="grid-row">
+		<div class="column-one-third">
+			<nav class="sub-navigation">
+				<ol itemscope itemtype="http://schema.org/ItemList">
+					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="/get-started" itemprop="item"><span itemprop="name">Evaluate the platform</span></a>
+					</li>
+					<li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+						<a href="/migrate-live-services" itemprop="item"><span itemprop="name">Migrate a live service to GOV.UK PaaS</span></a>
+					</li>
+				</ol>
+			</nav>
+		</div>
+
+		<div class="column-two-thirds">
+			<h1 class="heading-xlarge">Migrate a live service to GOV.UK PaaS</h2>
+			<p>
+				Any migration typically involves switching costs. In the case of GOV.UK PaaS you should consider:
+
+				<ul class="list list-bullet">
+					<li>the features we offer and the <a href="https://docs.cloud.service.gov.uk/#paas-requirements">languages and frameworks</a> we currently support</li>
+					<li>the releases planned in our <a href="/roadmap">roadmap</a> - bear in mind that we are always looking for private beta partners for new features</li>
+					<li>any work involved in making your applications follow the <a href="https://12factor.net/">12-factor app principles</a></li>
+					<li>the effort required to separate a monolithic service into components</li>
+				</ul>
+			</p>
+
+			<p>
+				Consider also the risks: some issues might only be visible when using production-scale data. We can mitigate that risk by granting short-term access to paid services, but tenants should be careful when using production data.
+			</p>
+
+			<p>
+				You should also evaluate the platform features with our 3-month trial period. If you think that GOV.UK PaaS could be an option for your service, get in contact with <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.
+			</p>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## What

### Update /get-started with new onboarding content

Taken from the Google Doc written by Paola. Updated `<title>` was agreed
with her afterwards. Have confirmed that the newlines in the last paragraph
are intentional.

### Add /migrate-live-services

Taken from the Google Doc written by Paola, including the new sidebar for
both pages in that section. We decided it was better to keep the URL of
`/get-started` even though it doesn't match the "Evaluate the platform" text
for the moment.

The `<title>` has been taken from the H1. We decided together not to use
"Get started with GOV.UK PaaS" as the H1 because it made less sense for this
page. URL for the new page was agreed with Jess and Paola.

### Downcase 2nd word in "Get Started" menu

As requested by Paola.

## How to review

1. Checkout the branch: `git fetch && git checkout feature/153050309-update_onboarding`
1. Install the dependencies: `bundle install`
1. Run the local webserver: `make dev`
1. View the new pages in a browser:
    1. http://localhost:9292/get-started
    1. http://localhost:9292/migrate-live-services
1. Confirm that the rendering looks OK
1. Confirm that all of the links works
    1. we have tests for links but they don't check that anchors exist and we use lots of them to refer to the tech docs

## Who can review

Ideally someone who has more recent experience in writing HTML than me. I'm going to leave some specific comments for Stephen, but someone else could do the rest of the review.