### PR TITLE
[#152916557] Create a Start using GOV.UK PaaS page

### DIFF
--- a/assets/stylesheets/_core.scss
+++ b/assets/stylesheets/_core.scss
@@ -145,3 +145,24 @@ table th {
 legend {
 	padding-left:0;
 }
+
+.govuk-box-highlight-green {
+	background: none;
+	border: 5px $green solid;
+	margin: 2em 0 0 0;
+	padding: 1em;
+
+	p {
+		color: $green;
+		font-weight: 700;
+		margin-bottom: .5em;
+		padding-top: 10px;
+	}
+}
+
+.download-section {
+	background-color: $highlight-colour;
+	border: 10px solid $panel-colour;
+	margin: 15px 0 5px;
+	padding: 5px;
+}

--- a/spec/next_steps_spec.rb
+++ b/spec/next_steps_spec.rb
@@ -1,0 +1,22 @@
+require 'rack/test'
+require 'capybara/rspec'
+require 'net/http'
+Capybara.app = Rack::Builder.parse_file("config.ru").first
+
+RSpec.describe 'Next steps', :type => :feature do
+
+  include Rack::Test::Methods
+
+  it 'should be able to load page successfully' do
+    visit '/next-steps'
+    expect(page).not_to have_selector('.account-created'), 'Did not expect to see "Your account has been activated" message'
+    expect(page.status_code).to eq(200)
+  end
+
+  it 'should be able to load page successfully with account activated message' do
+    visit '/next-steps?success'
+    expect(page).to have_selector('.account-created'), 'Expected to see "Your account has been activated" message'
+    expect(page.status_code).to eq(200)
+  end
+
+end

--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -39,6 +39,10 @@
 				When you <a href="/signup">request an account</a> you can invite as many team members as you need and choose the ones who’ll be in charge of managing users. They’ll be able to request more user accounts, including ones for external suppliers, and assign <a href="https://docs.cloud.service.gov.uk/#user-roles">roles and permissions</a>.
 			</p>
 
+			<p>
+				If you already have an account please refer to our <a href="/next-steps">Start using GOV.UK PaaS</a> page.
+			</p>
+
 			<h3 class="heading-medium">Push your first app</h3>
 			<p>
 				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">quick setup guide</a> will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.

--- a/views/next-steps.erb
+++ b/views/next-steps.erb
@@ -1,0 +1,117 @@
+<% content_for :head do %>
+    <title>Start using GOV.UK PaaS - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+    <%== erb :'partials/_breadcrumb', :locals => {name: 'Get started', href: '/get-started'} %>
+    <%== erb :'partials/_breadcrumb', :locals => {name: 'Start using GOV.UK PaaS', href: '/next-steps', active: true} %>
+<% end %>
+
+<div class="container">
+  <div class="grid-row">
+    <% if params.key?('success') %>
+        <div class="column-full">
+          <div class="govuk-box-highlight-green account-created">
+            <p>Your account has been activated</p>
+          </div>
+        </div>
+    <% end %>
+
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Start using GOV.UK PaaS
+      </h1>
+
+      <p class="lede">
+        A lot of the tasks you’ll need to do to operate GOV.UK PaaS will be done from your computers
+        command line interface.
+      <p>
+    </div>
+  </div>
+
+  <div class="grid-row download-section">
+    <div class="column-two-thirds">
+      <h2 class="heading-small">
+        Download the Cloud Foundry command line tool
+      </h2>
+
+      <p>
+        You’ll need to do this to operate GOV.UK PaaS from your terminal. You can download the cf command line tool
+        using one of the installers shown. You can also visit the github page for
+        <a href="https://github.com/cloudfoundry/cli#downloads">other download options</a> such as using package
+        managers.
+      </p>
+    </div>
+
+    <div class="column-one-third">
+      <p class="heading-small">Installation options: </p>
+
+      <ul class="list-bullet">
+        <li><a href="https://packages.cloudfoundry.org/stable?release=macosx64&amp;source=github">Mac OS X 64 bit</a></li>
+        <li><a href="https://packages.cloudfoundry.org/stable?release=windows64&amp;source=github">Windows 64 bit</a></li>
+        <li><a href="https://packages.cloudfoundry.org/stable?release=debian64&amp;source=github">Debian 64 bit</a></li>
+        <li><a href="https://packages.cloudfoundry.org/stable?release=redhat64&amp;source=github">RedHat 64 bit</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h2 class="heading-medium">Here are some tasks you can do next</h2>
+    </div>
+
+    <div class="column-one-third">
+      <h2 class="heading-small">
+        <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">Setup and deploy your first app</a>
+      </h2>
+
+      <p>View our quick setup guide on deploying your first app to GOV.UK PaaS.</p>
+    </div>
+
+    <div class="column-one-third">
+      <h2 class="heading-small">
+        <a href="https://docs.cloud.service.gov.uk/#managing-users">View and manage team members</a>
+      </h2>
+
+      <p>
+        If you are an ‘org manager’ you can administer team members. Learn how to do this using the command line
+        tool.
+      </p>
+    </div>
+
+    <div class="column-one-third">
+      <h2 class="heading-small">
+        <a href="https://docs.cloud.service.gov.uk">View all documentation</a>
+      </h2>
+
+      <p>
+        Our documentation covers all aspects of using GOV.UK PaaS, from managing and scaling your applications to
+        troubleshooting.
+      </p>
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-one-third">
+      <h2 class="heading-small">
+        <a href="/get-started">See steps to going live</a>
+      </h2>
+
+      <p>
+        See an overview of the steps your service needs to take to go live on GOV.UK PaaS.
+      </p>
+    </div>
+
+    <div class="column-one-third">
+      <!-- FIXME: Pricing calculator is not live yet.
+      <h2 class="heading-small">
+        <a href="/pricing-calculator-accordion">Get a cost estimation</a>
+      </h2>
+
+      <p>
+        Use our calculator to estimate how much it will cost your service to use GOV.UK PaaS.
+      </p>
+      -->
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## What

We think, that the default page the UAA redirects our tenants to is less
useful for them to get started. We'd like to provide them with as much
information as possible for them to find their way around PaaS.

Stephen has provided us with both the design and the prototype page,
which we decided could be integrated into the product page for being
static.

## How to review

- Code review
- Run `make dev`
- Navigate to `http://localhost:9292/next-steps`
- Navigate to `http://localhost:9292/next-steps?success` - experience success message
- Consult @stephenjoe1 if the design is still correct