### PR TITLE
[#153091168] Fix Dockerfile now bower is removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM ruby:2.3.3-alpine
+FROM ruby:2.4.1-alpine
 
-ENV RUNTIME_PACKAGES "git nodejs"
-ENV DEV_PACKAGES "gcc ruby-dev make g++ zlib-dev libffi-dev"
-COPY bower.json /tmp/bower.json
+ENV RUNTIME_PACKAGES "git make"
+ENV DEV_PACKAGES "gcc ruby-dev g++ zlib-dev libffi-dev"
 COPY Gemfile /tmp/Gemfile
+COPY .ruby-version /tmp/.ruby-version
 COPY Gemfile.lock /tmp/Gemfile.lock
 RUN apk add --update $RUNTIME_PACKAGES
 RUN apk add $DEV_PACKAGES \
-  && npm install -g bower \
   && gem install bundle --no-document \
   && cd /tmp && bundle \
   && apk del $DEV_PACKAGES \

--- a/release/test
+++ b/release/test
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "${ROOT_DIR}"
+
+make test


### PR DESCRIPTION
## What

Until this PR, the `Dockerfile` has expected a `bower.json` file to exist. We deleted it two months ago because the product page app no longer needs it. However, this meant that the DockerHub docker image builds started to fail--and have been doing so ever since.

Additionally, this PR makes the testsuite [be run before deploying from the release CI](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-product-page/jobs/test/builds/32).

## How to review

Code review should suffice. We've run the tests in the new `Dockerfile` successfully with something like `docker run -v /Users/michaelmokrysz/gds/paas-product-page:/paas-product-page fbc6fb9c22ee /bin/sh -c "cd paas-product-page; make test"`.

## Who can review

Not @46bit @camelpunch 