### PR TITLE
[#153091168] Deploy to www.(system domain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ node_modules
 
 # PaaS authentication file
 Staticfile.auth
+
+modified_manifest.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,6 @@ applications:
     instances: 2
     env:
       APP_ENV: production
+      DESKPRO_API_KEY:
+      DESKPRO_TEAM_ID: '1'
+      DESKPRO_ENDPOINT: 'https://gaap.deskpro.com'

--- a/release/generate-manifest
+++ b/release/generate-manifest
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+cf_system_dns_root = ENV['CF_API'].sub('https://api.', '')
+
+manifest = YAML.load($stdin.read)
+manifest['applications'].each { |app|
+  app['env']['DESKPRO_API_KEY'] = ENV['DESKPRO_API_KEY']
+  app['routes'] ||= []
+  app['routes'] << { 'route' => 'www.' + cf_system_dns_root }
+  app['routes'] << { 'route' => 'paas-product-page.cloudapps.digital' }
+}
+puts manifest.to_yaml

--- a/release/push
+++ b/release/push
@@ -3,23 +3,12 @@
 set -eu
 
 echo "Creating manifest"
-DESKPRO_API_KEY=`cat "../secrets/$SECRETS_FILE" | awk '/deskpro_api_key/ { print $2 }'`
-ruby -ryaml -e "
-	env = {
-		'DESKPRO_API_KEY' => '${DESKPRO_API_KEY}',
-		'DESKPRO_TEAM_ID' => '1',
-		'DESKPRO_ENDPOINT' => 'https://gaap.deskpro.com',
-	}
-	manifest = YAML.load_file('manifest.yml')
-	manifest['applications'].each { |app|
-		app['env'] = {} unless app['env']
-		app['env'].merge!(env)
-	}
-	File.write('manifest.yml', manifest.to_yaml)
-"
+export DESKPRO_API_KEY=`cat "../secrets/$SECRETS_FILE" | awk '/deskpro_api_key/ { print $2 }'`
+export CF_API
+release/generate-manifest \
+    < manifest.yml \
+    > modified_manifest.yml
 
 echo "Deploy with zero downtime"
-cf blue-green-deploy paas-product-page
-
-echo "Delete left over app"
-cf delete -f paas-product-page-old
+cf zero-downtime-push paas-product-page \
+    -f modified_manifest.yml

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -1,0 +1,42 @@
+require 'open3'
+
+describe "generating a manifest" do
+  let(:dir) { Pathname(File.absolute_path(__dir__) + '/..') }
+  let(:manifest_template) { dir.join('manifest.yml').read }
+
+  let(:new_manifest) {
+    cmd = dir.join('release', 'generate-manifest')
+
+    stdout, stderr, status = Open3.capture3(
+      {
+        'DESKPRO_API_KEY' => 'my-great-deskpro-api-key',
+        'CF_API' => 'https://api.foo.bar.baz',
+      },
+      cmd.to_s,
+      stdin_data: manifest_template
+    )
+
+    expect(stderr).to be_empty
+    YAML.load(stdout)
+  }
+
+  it "adds a www.SYSTEM_DOMAIN route" do
+    expect(new_manifest['applications'][0]['routes']).
+      to include({ 'route' => 'www.foo.bar.baz' })
+  end
+
+  it "adds the cloudapps.digital route" do
+    expect(new_manifest['applications'][0]['routes']).
+      to include({ 'route' => 'paas-product-page.cloudapps.digital' })
+  end
+
+  it "sets the DeskPro API key" do
+    expect(new_manifest['applications'][0]['env']['DESKPRO_API_KEY']).
+      to eq('my-great-deskpro-api-key')
+  end
+
+  it "preserves the existing env" do
+    expect(new_manifest['applications'][0]['env']['DESKPRO_TEAM_ID']).
+      to eq('1')
+  end
+end


### PR DESCRIPTION
## What

The product page app is mostly served as HTML files. However, we redirect `.html` requests to strip out the extension. Before this change, this redirect would take people onto the `cloudapps.digital` domain. For instance, visiting `https://www.cloud.service.gov.uk/get-started.html` gives a redirect to `https://paas-product-page.cloudapps.digital/get-started`. This is because the app is only seeing a hostname of `paas-product-page.cloudapps.digital`.

This adds a new hostname to the deployed app, which in production will be `www.cloud.service.gov.uk` and in development would be `www.${DEPLOY_ENV}.dev.cloudpipeline.digital`. We are separately configuring CloudFront to provide `Host: www.cloud.service.gov.uk`, and this new route will mean the app will receive such requests and redirect correctly.

## How to review

Code review.

## Who can review

Not @camelpunch @46bit