### PR TITLE
[#153091168] Revert "Run tests when deploying from Concourse"

### DIFF
--- a/release/test
+++ b/release/test
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
-cd "${ROOT_DIR}"
-
-make test


### PR DESCRIPTION
## What

This reverts a commit from #43 which caused the `test` task in our build Concourse to fail. See commit messages for details.

## How to review

Realistically, code review and then see if `test` passes.

## Who can review

Not @46bit