### PR TITLE
[#153697787] Add redirect application for CF domain redirects

### DIFF
--- a/redirect/manifest.yml
+++ b/redirect/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+  - name: paas-product-page-redirect
+    buildpack: staticfile_buildpack
+    memory: 32M
+    instances: 2

--- a/redirect/nginx.conf
+++ b/redirect/nginx.conf
@@ -1,0 +1,27 @@
+# This configuration is based from the CloudFoundry static buildpack's default, which you can view here:
+# https://github.com/cloudfoundry/staticfile-buildpack/blob/bd7a288e11b27f1c5095d62bcd09780a14c5151e/conf/nginx.conf
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      return 301 https://<%= ENV["REDIRECT_DOMAIN"] %>$request_uri;
+    }
+  }
+}

--- a/release/generate-manifest
+++ b/release/generate-manifest
@@ -3,12 +3,13 @@
 require 'yaml'
 
 cf_system_dns_root = ENV['CF_API'].sub('https://api.', '')
+cf_apps_domain = ENV['CF_APPS_DOMAIN']
 
 manifest = YAML.load($stdin.read)
 manifest['applications'].each { |app|
   app['env']['DESKPRO_API_KEY'] = ENV['DESKPRO_API_KEY']
   app['routes'] ||= []
   app['routes'] << { 'route' => 'www.' + cf_system_dns_root }
-  app['routes'] << { 'route' => 'paas-product-page.cloudapps.digital' }
+  app['routes'] << { 'route' => 'paas-product-page.' + cf_apps_domain }
 }
 puts manifest.to_yaml

--- a/release/generate-manifest
+++ b/release/generate-manifest
@@ -3,13 +3,11 @@
 require 'yaml'
 
 cf_system_dns_root = ENV['CF_API'].sub('https://api.', '')
-cf_apps_domain = ENV['CF_APPS_DOMAIN']
 
 manifest = YAML.load($stdin.read)
 manifest['applications'].each { |app|
   app['env']['DESKPRO_API_KEY'] = ENV['DESKPRO_API_KEY']
   app['routes'] ||= []
   app['routes'] << { 'route' => 'www.' + cf_system_dns_root }
-  app['routes'] << { 'route' => 'paas-product-page.' + cf_apps_domain }
 }
 puts manifest.to_yaml

--- a/release/generate-redirect-manifest
+++ b/release/generate-redirect-manifest
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+cf_system_dns_root = ENV['CF_API'].sub('https://api.', '')
+cf_apps_domain = ENV['CF_APPS_DOMAIN']
+cf_app_name = ENV['CF_APP_NAME']
+
+manifest = YAML.load($stdin.read)
+manifest['applications'].each { |app|
+  app['routes'] ||= []
+  app['routes'] << { 'route' => cf_app_name + '.' + cf_apps_domain }
+
+  app['env'] ||= {}
+  app['env']['REDIRECT_DOMAIN'] = 'www.' + cf_system_dns_root
+}
+puts manifest.to_yaml

--- a/release/push
+++ b/release/push
@@ -5,6 +5,7 @@ set -eu
 echo "Creating manifest"
 export DESKPRO_API_KEY=`cat "../secrets/$SECRETS_FILE" | awk '/deskpro_api_key/ { print $2 }'`
 export CF_API
+export CF_APPS_DOMAIN
 release/generate-manifest \
     < manifest.yml \
     > modified_manifest.yml

--- a/release/push
+++ b/release/push
@@ -2,14 +2,25 @@
 
 set -eu
 
-echo "Creating manifest"
+PROJECT_DIR=$(cd "$(dirname "$0")/../" && pwd)
+CURRENT_DIR=$(pwd)
+
+export CF_APP_NAME=paas-product-page
 export DESKPRO_API_KEY=`cat "../secrets/$SECRETS_FILE" | awk '/deskpro_api_key/ { print $2 }'`
 export CF_API
 export CF_APPS_DOMAIN
+
+${PROJECT_DIR}/release/push-redirect
+
+cd ${PROJECT_DIR}
+
+echo "Creating ${CF_APP_NAME} manifest"
 release/generate-manifest \
     < manifest.yml \
     > modified_manifest.yml
 
-echo "Deploy with zero downtime"
-cf zero-downtime-push paas-product-page \
+echo "Deploying ${CF_APP_NAME} with zero downtime"
+cf zero-downtime-push ${CF_APP_NAME} \
     -f modified_manifest.yml
+
+cd ${CURRENT_DIR}

--- a/release/push-redirect
+++ b/release/push-redirect
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_DIR=$(cd "$(dirname "$0")/../" && pwd)
+CURRENT_DIR=$(pwd)
+
+export CF_API
+export CF_APPS_DOMAIN
+export CF_APP_NAME
+
+cd ${PROJECT_DIR}/redirect
+
+echo "Creating ${CF_APP_NAME}-redirect manifest"
+${PROJECT_DIR}/release/generate-redirect-manifest \
+    < manifest.yml \
+    > modified_manifest.yml
+
+echo "Deploying ${CF_APP_NAME}-redirect with zero downtime"
+cf zero-downtime-push ${CF_APP_NAME}-redirect \
+    -f modified_manifest.yml
+
+cd ${CURRENT_DIR}

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -11,6 +11,7 @@ describe "generating a manifest" do
       {
         'DESKPRO_API_KEY' => 'my-great-deskpro-api-key',
         'CF_API' => 'https://api.foo.bar.baz',
+        'CF_APPS_DOMAIN' => 'apps.foo.bar.baz'
       },
       cmd.to_s,
       stdin_data: manifest_template
@@ -27,7 +28,7 @@ describe "generating a manifest" do
 
   it "adds the cloudapps.digital route" do
     expect(new_manifest['applications'][0]['routes']).
-      to include({ 'route' => 'paas-product-page.cloudapps.digital' })
+      to include({ 'route' => 'paas-product-page.apps.foo.bar.baz' })
   end
 
   it "sets the DeskPro API key" do

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -11,7 +11,6 @@ describe "generating a manifest" do
       {
         'DESKPRO_API_KEY' => 'my-great-deskpro-api-key',
         'CF_API' => 'https://api.foo.bar.baz',
-        'CF_APPS_DOMAIN' => 'apps.foo.bar.baz'
       },
       cmd.to_s,
       stdin_data: manifest_template
@@ -26,11 +25,6 @@ describe "generating a manifest" do
       to include({ 'route' => 'www.foo.bar.baz' })
   end
 
-  it "adds the cloudapps.digital route" do
-    expect(new_manifest['applications'][0]['routes']).
-      to include({ 'route' => 'paas-product-page.apps.foo.bar.baz' })
-  end
-
   it "sets the DeskPro API key" do
     expect(new_manifest['applications'][0]['env']['DESKPRO_API_KEY']).
       to eq('my-great-deskpro-api-key')
@@ -40,4 +34,34 @@ describe "generating a manifest" do
     expect(new_manifest['applications'][0]['env']['DESKPRO_TEAM_ID']).
       to eq('1')
   end
+
+  let(:redirect_manifest_template) { dir.join('redirect/manifest.yml').read }
+
+  let(:new_redirect_manifest) {
+    cmd = dir.join('release', 'generate-redirect-manifest')
+
+    stdout, stderr, status = Open3.capture3(
+      {
+        'CF_API' => 'https://api.foo.bar.baz',
+        'CF_APPS_DOMAIN' => 'apps.foo.bar.baz',
+        'CF_APP_NAME' => 'paas-product-page',
+      },
+      cmd.to_s,
+      stdin_data: redirect_manifest_template
+    )
+
+    expect(stderr).to be_empty
+    YAML.load(stdout)
+  }
+
+  it "adds the cloudapps.digital route" do
+    expect(new_redirect_manifest['applications'][0]['routes']).
+      to include({ 'route' => 'paas-product-page.apps.foo.bar.baz' })
+  end
+
+  it "sets the REDIRECT_DOMAIN environment variable" do
+    expect(new_redirect_manifest['applications'][0]['env']).
+      to include({ 'REDIRECT_DOMAIN' => 'www.foo.bar.baz' })
+  end
+
 end


### PR DESCRIPTION
## What

Add redirect application for CF domain redirects

Any direct HTTP request to paas-product-page.<CF apps domain> should redirect to www.<CF system domain>. For this purpose we deploy a simple staticfile app with an Nginx configuration.

## How to review

1. Update your build Concourse:
   ```BRANCH=redirect_cf_domain_153697787 CF_API=https://api.${DEPLOYER_DEPLOY_ENV}.dev.cloudpipeline.digital CF_APPS_DOMAIN=${DEPLOYER_DEPLOY_ENV}.dev.cloudpipelineapps.digital SELF_UPDATE_PIPELINE=false make dev pipelines```
1. Change temporarily the ${DEPLOYER_DEPLOY_ENV}-cf-api security group to allow traffic from your build Concourse
1. Enable and run the paas-product-page pipeline
1. Test if calling the https://paas-product-page.${DEPLOYER_DEPLOY_ENV}.dev.cloudpipelineapps.digital redirects you to https://www.${DEPLOYER_DEPLOY_ENV}.dev.cloudpipeline.digital and keeps the query parameters. (An http request will be redirected to the domain without the query parameters and it's done by the router).

## Who can review

Not @bandesz
