### PR TITLE
[#143584125] Add 'account updated' notice

### DIFF
--- a/spec/next_steps_spec.rb
+++ b/spec/next_steps_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe 'Next steps', :type => :feature do
     expect(page.status_code).to eq(200)
   end
 
+  it 'should be able to load page successfully with account-updated message' do
+    visit '/next-steps?account-updated'
+    expect(page).to have_selector('.account-updated'), 'Expected to see "Your account has been updated" message'
+    expect(page.status_code).to eq(200)
+  end
+
 end

--- a/views/next-steps.erb
+++ b/views/next-steps.erb
@@ -17,6 +17,14 @@
         </div>
     <% end %>
 
+    <% if params.key?('account-updated') %>
+        <div class="column-full">
+          <div class="govuk-box-highlight-green account-updated">
+            <p>Your account has been updated</p>
+          </div>
+        </div>
+    <% end %>
+
     <div class="column-two-thirds">
       <h1 class="heading-large">
         Access GOV.UK PaaS


### PR DESCRIPTION
# What

After user has completed the reset password flow they are redirected to
the page "/next-steps?account-updated".

This displays a short notice at the top of the page (similar to the
"?success" message) to indicate the flow was completed successfully

# How to review

* check changes/wording
* run `make dev` from this branch
* visit `http://localhost:9292/next-steps`

# Who can review

Not @chrisfarms