### PR TITLE
Do not use `which -s` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 vendor: # reinstall ruby dependencies
-	@which -s bundle || (echo 'bundler is required to install application dependencies. Install Ruby + bundler' && false)
+	@which bundle > /dev/null 2>&1 || (echo 'bundler is required to install application dependencies. Install Ruby + bundler' && false)
 	bundle install --path vendor/bundle
 
 .PHONY: test


### PR DESCRIPTION
`which -s` only works on MacOSX[1] but not on Linux.[2] Because that
building or testing the project fails on linux.

The option is to do not print the output, which can be done in
a portable way by redirecting to /dev/null:

          -s      No output, just return 0 if any of the executables are
          found, or 1 if none are found.

[1] https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/which.1.html
[2] https://linux.die.net/man/1/which