### PR TITLE
[#154514300] Security info

### DIFF
--- a/views/features.erb
+++ b/views/features.erb
@@ -10,19 +10,7 @@
 	<div class="grid-row">
 
 		<div class="column-one-third">
-			<nav class="sub-navigation">
-				<ol itemscope itemtype="http://schema.org/ItemList">
-					<li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/features" itemprop="item"><span itemprop="name">Features</span></a>
-					</li>
-					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
-					</li>
-					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
-					</li>
-				</ol>
-			</nav>
+			<%== erb :'partials/_subnav', :locals => {active: 'features'} %>
 		</div>
 
 

--- a/views/features.erb
+++ b/views/features.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :breadcrumb do %>
-	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and pricing', href: request.path_info, active: true} %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and security', href: request.path_info, active: true} %>
 <% end %>
 
 <div class="container">
@@ -29,6 +29,9 @@
 				<li>It allows SSH access to containers</li>
 				<li>Applications running on the platform are isolated from each other so they can’t read or change each other's code, data or logs</li>
 			</ul>
+			<p class="content-section__body">
+				<a href="/security">Read more about how we keep GOV.UK PaaS secure</a>
+			</p>
 			<h2 class="heading-medium">Languages supported</h2>
 			<ul class="list list-bullet">
 				<li>Go</li>

--- a/views/ia.erb
+++ b/views/ia.erb
@@ -1,0 +1,32 @@
+<% content_for :head do %>
+	<title>Features - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and security', href: request.path_info, active: true} %>
+<% end %>
+
+<div class="container">
+	<div class="grid-row">
+
+		<div class="column-one-third">
+			<%== erb :'partials/_subnav', :locals => {active: 'ia'} %>
+		</div>
+
+
+		<div class="column-two-thirds">
+			<h1 class="heading-xlarge">Information assurance</h1>
+
+			<h2 class="heading-medium">Platform assurance</h2>
+			<p>The platform has been assured by the Cabinet Office Senior Information Risk Owner (SIRO) and our information and security risk is deemed to be appropriate for data classified as ‘official’. In order to operate with live services, we underwent a formal risk assessment using a methodology based on ISO27005:2011. Our service is currently subject to the Cabinet Office and the Government Digital Service security governance.</p>
+			<p>Contact us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you need details on our Information Risk Management, or <a href="/security">read more about our platform security measures</a>.</p>
+
+			<h2 class="heading-medium">Your service assurance</h2>
+			<p>You’ll be responsible for the assurance of your own service, and making sure that you have in place appropriate controls for the information you handle.</p>
+			<p>When you assure your service through your own organisation’s information assurance (security) process, you don’t need to include assurance of GOV.UK PaaS, since we’ve already done that - we can share the work we’ve done with you.</p>
+			<p>GOV.UK PaaS runs from Amazon Web Services in Ireland. Our offshore request for ‘official’ data was successful, but your department’s information assurance team will need to make another offshoring request, so that the Office of the Government’s Senior Information Risk Owner (OGSIRO) is aware of any increase to our aggregate risk.</p>
+			<p>Contact us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you need more details about information assurance.</p>
+
+		</div>
+	</div>
+</div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -118,6 +118,9 @@
 						The technology runs on an IA-accredited infrastructure, so times for app accreditation are generally faster
 					</li>
 				</ul>
+				<p class="content-section__body">
+					<a href="/security">Read more about how we keep GOV.UK PaaS secure</a>
+				</p>
 			</div>
 		</div>
 	</section>

--- a/views/partials/_subnav.erb
+++ b/views/partials/_subnav.erb
@@ -1,0 +1,13 @@
+<nav class="sub-navigation">
+	<ol itemscope itemtype="http://schema.org/ItemList">
+		<li class="sub-navigation__item sub-navigation <%= active == 'features' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/features" itemprop="item"><span itemprop="name">Features</span></a>
+		</li>
+		<li class="sub-navigation__item <%= active == 'roadmap' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
+		</li>
+		<li class="sub-navigation__item <%= active == 'pricing' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
+		</li>
+	</ol>
+</nav>

--- a/views/partials/_subnav.erb
+++ b/views/partials/_subnav.erb
@@ -9,6 +9,9 @@
 		<li class="sub-navigation__item <%= active == 'pricing' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 			<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
 		</li>
+		<li class="sub-navigation__item <%= active == 'ia' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/ia" itemprop="item"><span itemprop="name">Information assurance</span></a>
+		</li>
 		<li class="sub-navigation__item <%= active == 'security' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 			<a href="/security" itemprop="item"><span itemprop="name">Security</span></a>
 		</li>

--- a/views/partials/_subnav.erb
+++ b/views/partials/_subnav.erb
@@ -9,5 +9,8 @@
 		<li class="sub-navigation__item <%= active == 'pricing' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 			<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
 		</li>
+		<li class="sub-navigation__item <%= active == 'security' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/security" itemprop="item"><span itemprop="name">Security</span></a>
+		</li>
 	</ol>
 </nav>

--- a/views/pricing.erb
+++ b/views/pricing.erb
@@ -9,19 +9,7 @@
 <div class="container">
 	<div class="grid-row">
 		<div class="column-one-third">
-			<nav class="sub-navigation">
-				<ol itemscope itemtype="http://schema.org/ItemList">
-					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/features" itemprop="item"><span itemprop="name">Features</span></a>
-					</li>
-					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
-					</li>
-					<li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
-					</li>
-				</ol>
-			</nav>
+			<%== erb :'partials/_subnav', :locals => {active: 'pricing'} %>
 		</div>
 
 

--- a/views/pricing.erb
+++ b/views/pricing.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :breadcrumb do %>
-	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and pricing', href: request.path_info, active: true} %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and security', href: request.path_info, active: true} %>
 <% end %>
 
 <div class="container">

--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :breadcrumb do %>
-	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and pricing', href: request.path_info, active: true} %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and security', href: request.path_info, active: true} %>
 <% end %>
 
 <div class="container">

--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -9,19 +9,7 @@
 <div class="container">
 	<div class="grid-row">
 		<div class="column-one-third">
-			<nav class="sub-navigation">
-				<ol itemscope itemtype="http://schema.org/ItemList">
-					<li class="sub-navigation__item sub-navigation" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/features" itemprop="item"><span itemprop="name">Features</span></a>
-					</li>
-					<li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/roadmap" itemprop="item"><span itemprop="name">Roadmap</span></a>
-					</li>
-					<li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-						<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
-					</li>
-				</ol>
-			</nav>
+			<%== erb :'partials/_subnav', :locals => {active: 'roadmap'} %>
 		</div>
 
 		<div class="column-two-thirds">

--- a/views/security.erb
+++ b/views/security.erb
@@ -1,0 +1,97 @@
+<% content_for :head do %>
+	<title>Features - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Features, roadmap and security', href: request.path_info, active: true} %>
+<% end %>
+
+<div class="container">
+	<div class="grid-row">
+
+		<div class="column-one-third">
+			<%== erb :'partials/_subnav', :locals => {active: 'security'} %>
+		</div>
+
+
+		<div class="column-two-thirds">
+			<h1 class="heading-xlarge">Security</h1>
+
+			<h2 class="heading-medium">Our safety measures</h2>
+			<p>The platform is designed to meet both the <a href="https://www.ncsc.gov.uk/guidance/implementing-cloud-security-principles">Cloud Security Principles</a> and the common security needs of data classified as ‘official’:</p>
+			<ul class="list list-bullet">
+				<li>data in transit is protected by HTTPS from the client to the platform</li>
+				<li>IPSec secures data when routing traffic across the platform to your application</li> 
+				<li>connections from your application to backing services require TLS</li>
+				<li>we host on Amazon Web Services (AWS) - their physical security procedures are <a href="http://d0.awsstatic.com/whitepapers/compliance/AWS_CESG_UK_Cloud_Security_Principles.pdf">robust and audited</a></li>
+				<li>data in backing services can be encrypted at rest</li>
+				<li>separation between users of the platform is enforced by Cloud Foundry’s internal authentication and access control system</li>
+				<li>Linux containers provide the boundary between running application instances</li>
+				<li>the platform relies on robust operational security and processes (see below)</li>
+				<li>it’s possible to change and revoke your team members’ permissions and roles to manage the service (tenants will be able to add new users later in 2018)</li>
+				<li>we use 2-factor authentication, short-lived credentials and IP restriction policies for identity and access management to protect AWS resources</li>
+				<li>shared credentials are rotated to minimise risk of unauthorised access</li>
+				<li>Amazon Cloudtrail audits and monitors AWS activity</li>
+				<li>the CloudFoundry events API provides audit information about the use of your service</li>
+			</ul>
+
+			<h2 class="heading-medium">How we manage change, vulnerabilities and incidents</h2>
+			<p>The platform is built and maintained by a government team within the Government Digital Service, and these are the established working practices:</p>
+			<ul class="list list-bullet">
+				<li>everyone with production access has Security Check (SC) clearance</li>
+				<li>code changes are approved by team members who haven’t worked on the feature</li>
+				<li>we do pair programming whenever possible</li>
+				<li>system configuration and access privileges are under source code control
+					and so is documentation</li>
+				<li>control changes to the production platform are overseen by civil servants</li>
+				<li>we code in the open and our code is available in the <a href="https://github.com/alphagov">alphagov</a> project on GitHub - search for the ‘paas’ repositories</li>
+				<li>we have a tried and tested incident management approach</li>
+				<li>reports of incidents are published and available on our <a href="https://status.cloud.service.gov.uk/history">status page</a></li>
+				<li>external penetration tests (IT Health Checks) of the platform are carried out annually and it’s our policy to address all issues discovered with a CVSS score of medium or above</li>
+				<li>when security updates become available, we start working on them within one working day, prioritising fixes to critical severity vulnerabilities</li>
+			</ul>
+			<p>If you need more information, contact us at: <br> <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a></p>
+
+			<h2 class="heading-medium">Who’s responsible for what</h2>
+			<table>
+				<thead>
+					<tr>
+						<th scope="col">Your responsibility</th>
+						<th scope="col">Our responsibility</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Security of the application design and code</td>
+						<td>Security of the platform</td>
+					</tr>
+					<tr>
+						<td>Applying security updates to application dependencies</td>
+						<td>Applying security updates to the platform including the underlying operating system</td>
+					</tr>
+					<tr>
+						<td>Updating custom buildpacks (if you use them)</td>
+						<td>Updating system buildpacks</td>
+					</tr>
+					<tr>
+						<td>Applying security updates to your Docker images (if you use them)</td>
+						<td>Applying security updates to backing services</td>
+					</tr>
+					<tr>
+						<td>Telling us if you experience any security breaches</td>
+						<td>Telling you if the platform experiences any security breaches</td>
+					</tr>
+					<tr>
+						<td>Performing penetration testing on your applications</td>
+						<td>Performing penetration testing on the platform</td>
+					</tr>
+					<tr>
+						<td></td>
+						<td>Setting defaults that optimise for security</td>
+					</tr>
+				</tbody>
+			</table>
+
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
# What

* DRYs up the subnav into a partial
* Adds `/security` page documenting security responsibility
* Adds `/ia` page documenting Information Assurance

# How to review

Use `make dev` locally to render the pages and check them out.

# Who can review

Not @chrisfarms
