### PR TITLE
[#154514300] Fix Security and IA page titles

### DIFF
--- a/views/ia.erb
+++ b/views/ia.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-	<title>Features - <%= settings.title %></title>
+	<title>Information assurance - <%= settings.title %></title>
 <% end %>
 
 <% content_for :breadcrumb do %>

--- a/views/security.erb
+++ b/views/security.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-	<title>Features - <%= settings.title %></title>
+	<title>Security - <%= settings.title %></title>
 <% end %>
 
 <% content_for :breadcrumb do %>


### PR DESCRIPTION
# What

I missed the page `<titles>` for security and ia pages, and left them as "features"

This sets them correctly.

# How to review

Check the titles

# Who can review

Not @chrisfarms