### PR TITLE
Remove dependency on CF upstream developments

### DIFF
--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -45,7 +45,7 @@
 				<li>CDN as a Service</li>
 				<li>CI as a Service</li>
 				<li>Memcache</li>
-				<li>VM isolation, dependent on Cloud Foundry upstream developments</li>
+				<li>VM isolation</li>
 			</ul>
 			
 			<h2 class="heading-medium">Development stages</h2>


### PR DESCRIPTION
## What

The dependency was on isolation segments, which shipped a long time ago.

## How to review

Read the [Cloud Foundry isolation segments doc](https://docs.cloudfoundry.org/adminguide/isolation-segments.html) and confirm that this would provide this feature.

## Who can review

According to the contribution guidelines only a member of the GaaP content team. But possibly @jollery or @pauldougan 