### PR TITLE
[#157390225] Add support and response times page and update old support page

### DIFF
--- a/views/partials/_subnav.erb
+++ b/views/partials/_subnav.erb
@@ -9,6 +9,9 @@
 		<li class="sub-navigation__item <%= active == 'pricing' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 			<a href="/pricing" itemprop="item"><span itemprop="name">Pricing</span></a>
 		</li>
+		<li class="sub-navigation__item <%= active == 'support-and-response-times' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+			<a href="/support-and-response-times" itemprop="item"><span itemprop="name">Support and response times</span></a>
+		</li>
 		<li class="sub-navigation__item <%= active == 'ia' ? 'sub-navigation__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 			<a href="/ia" itemprop="item"><span itemprop="name">Information assurance</span></a>
 		</li>

--- a/views/support-and-response-times.erb
+++ b/views/support-and-response-times.erb
@@ -34,7 +34,7 @@
 			Between 5pm and 9am on Monday to Friday, at weekends and during bank holidays (‘out of hours’ support) we provide emergency support for critical incidents affecting live production services.
 			</p>
 			<p>
-			Tenants with services in production can also contact us to escalate a critical issue out of working hours.
+			Tenants with services in production can contact us to <a href="/support">notify and escalate about a critical issue out of working hours</a>.
 			</p>
 
 			<h2 class="heading-large"><a name="response_times">Response and resolution times for services in production</a></h2>

--- a/views/support-and-response-times.erb
+++ b/views/support-and-response-times.erb
@@ -21,7 +21,7 @@
 			You can email us for support at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.
 			</p>
 			<p>
-			From Monday to Friday, between 9 and 5 and excluding bank holidays (‘in hours’ support), our <a href="#response_times">response times</a> range from 20 minutes to 1 business day depending on:
+			From Monday to Friday, between 9 and 5 and excluding bank holidays (‘in hours’ support), our response times (see below) range from 20 minutes to 1 business day depending on:
 			</p>
 			<ul class="list list-bullet">
 				<li>the nature of the request - we prioritise issues over queries</li>

--- a/views/support-and-response-times.erb
+++ b/views/support-and-response-times.erb
@@ -1,0 +1,125 @@
+<% content_for :head do %>
+	<title>Support and response times - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Support and response times', href: request.path_info, active: true} %>
+<% end %>
+
+<div class="container">
+	<div class="grid-row">
+		<div class="column-one-third">
+			<%== erb :'partials/_subnav', :locals => {active: 'support-and-response-times'} %>
+		</div>
+
+		<div class="column-two-thirds">
+			<h1 class="heading-xlarge">How we support the platform and our tenants</h1>
+			<p>
+			GOV.UK PaaS is supported 24 hours a day, 7 days a week by the team that builds it. Our <a href="https://docs.cloud.service.gov.uk/#responsibility-model">responsibility model</a> details the areas we cover.
+			</p>
+			<p>
+			You can email us for support at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.
+			</p>
+			<p>
+			From Monday to Friday, between 9 and 5 and excluding bank holidays (‘in hours’ support), our <a href="#response_times">response times</a> range from 20 minutes to 1 business day depending on:
+			</p>
+			<ul class="list list-bullet">
+				<li>the nature of the request - we prioritise issues over queries</li>
+				<li>the severity of the issue</li>
+				<li>whether it affects a live service</li>
+				<li>whether it was raised during or outside of working hours</li>
+			</ul>
+
+			<p>
+			Between 5pm and 9am on Monday to Friday, at weekends and during bank holidays (‘out of hours’ support) we provide emergency support for critical incidents affecting live production services.
+			</p>
+			<p>
+			Tenants with services in production can also contact us to escalate a critical issue out of working hours.
+			</p>
+
+			<h2 class="heading-large"><a name="response_times">Response and resolution times for services in production</a></h2>
+			<p>
+			We address incidents, issues and requests within the timeframes detailed below:
+			</p>
+
+			<table>
+				<tbody>
+					<tr>
+						<th>Classification</th>
+						<th>Example</th>
+						<th>In hours</th>
+						<th>Out of hours</th>
+					</tr>
+					<tr>
+						<th scope="row">P1<br/>Critical<br/>Incident</th>
+						<td>
+							<ul class="list list-bullet">
+								<li  class="font-xsmall">Applications are unavailable to end users due to a problem with our platform</li>
+								<li  class="font-xsmall">Serious security breach on the platform</li>
+								<li  class="font-xsmall">You can't make a critical fix to your production app due to the PaaS API not being available</li>
+								<li  class="font-xsmall">Your live production app has a P1 issue which cannot be resolved without help from us</li>
+							</ul>
+						</td>
+						<td>
+							<p class="font-xsmall">Start work &amp; respond: 20 minutes</p>
+							<p class="font-xsmall">Update time: 1hr</p>
+						</td>
+						<td>
+							<p class="font-xsmall">Start work &amp; respond: 40 minutes</p>
+							<p class="font-xsmall">Update time: 1hr</p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">P2<br/>Major<br/>Incident</th>
+						<td>
+							<ul class="list list-bullet">
+								<li class="font-xsmall">Can&apos;t update/push apps due to platform issue</li>
+								<li class="font-xsmall">Upstream vulnerabilities in GOV.UK PaaS components</li>
+								<li class="font-xsmall">Elevated error rates on the GOV.UK PaaS platform</li>
+								<li class="font-xsmall">Complete failure of a GOV.UK PaaS component</li>
+								<li class="font-xsmall">Substantial degradation of the GOV.UK PaaS service</li>
+							</ul>
+						</td>
+						<td>
+							<p class="font-xsmall">Start work &amp; respond: 30 minutes</p>
+							<p class="font-xsmall">Update time: 2hr</p>
+						</td>
+						<td>
+							<p class="font-xsmall"></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">P3<br/>Significant<br/>issue</th>
+						<td>
+							<ul class="list list-bullet">
+								<li class="font-xsmall">Users (platform users or end users) experiencing intermittent or degraded service due to platform issue.</li>
+							</ul>
+						</td>
+						<td>
+							<p class="font-xsmall">Start work &amp; respond: 2 hours</p>
+							<p class="font-xsmall">Update time: 4 hours</p>
+						</td>
+						<td>
+							<p class="font-xsmall"></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">P4<br/>Minor<br/>issue</th>
+						<td>
+							<ul class="list list-bullet">
+								<li class="font-xsmall">Component failure that is not immediately impacting on service</li>
+							</ul>
+						</td>
+						<td>
+							<p class="font-xsmall">Start work &amp; respond: 1 business day</p>
+							<p class="font-xsmall">Update time: 2 business days</p>
+						</td>
+						<td>
+							<p class="font-xsmall"></p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>

--- a/views/support.erb
+++ b/views/support.erb
@@ -9,123 +9,48 @@
 <div class="container">
 	<div class="grid-row">
 		<div class="column-two-thirds">
-			<h1 class="heading-xlarge">How GOV.UK PaaS is supported</h1>
-			<p> GOV.UK PaaS is supported 24 hours a day, seven days a week by the team that builds it. Response times and resolutions vary depending on the service status.  </p>
-			<p>You can view the availability and database connectivity of live applications on GOV.UK PaaS on our <a href="https://status.cloud.service.gov.uk/">system status page</a>. If you have a critical issue, start by checking this page: if it’s an issue with GOV.UK PaaS we’re already working on it, and we’ll keep our users updated on the progression of the incident.</p>
-			<h2 class="heading-large">Support during working hours</h2>
-			<p>Our office hours are 9am - 5pm Monday to Friday. You can email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to:</p>
-			<ul class="list list-bullet">
-				<li>report issues and incidents</li>
-				<li>get help using GOV.UK PaaS</li>
-			</ul>
-			<p>We prioritise fixing issues with the platform over answering user queries, and support for live services over support for services in development. For more information on how we respond to requests, you can look at our <a href="https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas">technical documentation</a>.</p>
-		</p>
+			<h1 class="heading-xlarge">Get support</h1>
+			<p>
+			You can view the availability and database connectivity of live applications on GOV.UK PaaS on <a href="https://status.cloud.service.gov.uk/">our system status page</a>. If you have a critical issue, start by checking this page: if it’s an issue with GOV.UK PaaS we’re already working on it, and we’ll keep our users updated on the progression of the incident.
+			</p>
 
-		<h2 class="heading-large">Support outside of working hours</h2>
-		<p> Between 5pm and 9am on Monday to Friday, at weekends and during Bank Holidays we provide emergency support for critical incidents affecting live production services.  A critical incident is where: </p>
-		<ul class="list list-bullet">
-			<li> your application is unavailable due to a problem with our platform </li>
-			<li> you can’t make a critical upgrade to your application because the GOV.UK PaaS API isn’t available </li>
-			<li> you are experiencing a critical issue with your application that you cannot resolve without help from the platform team.  </li>
-		</ul>
-		<p> We’ll start working on the issue within 40 minutes and email you to let you know. We’ll address anything that is not a critical incident the next working day.  </p>
-		<p>If GOV.UK PaaS shows as working and you have a critical issue outside of working hours, please use the emergency email address you have been given. This will raise a high priority ticket which could alert us during the night, so it should only be used for critical P1 incidents. Please do not share this email address with people outside of your team.</p>
+			<h2 class="heading-large">Report an issue</h2>
+			<p>
+			You can email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.
+			</p>
+			<p>
+			We will start working on critical issues impacting production services within 20 or 40 minutes, depending on the time of the day. Read more about <a href="/support-and-response-times#response_times">how we classify issues and our response times</a>.
+			</p>
+			<p>
+If you have a critical issue outside of working hours and you want to get in touch with us, use the emergency email address you have been given. It will raise a high priority ticket that could alert us during the night, so it should only be used for critical incidents. Please do not share this email address with people outside of your team.
+			</p>
 
-		<h2 class="heading-large">Response and resolution times for services in production</h2>
-		<p> We address incidents, issues and requests within the timeframes detailed below: </p>
+			<h2 class="heading-large">Get help using the platform</h2>
+			<p>If you need help using GOV.UK PaaS, you can send your queries to <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>. We’ll reply to your question as soon as possible, however we do prioritise support for incidents and issues to general queries. If you get in contact outside of working hours we’ll check your query on the next business day.</p>
 
-	</div>
-	<div class="column-full">
+			<h2 class="heading-large">Escalate support requests</h2>
+			<p>
+			If we are not handling your request for support in the way you would expect, please contact a member of the product team, who will reply during working hours:
+			</p>
+			<p>
+			Jess O'Leary, product manager - <a href="mailto:jessica.oleary@digital.cabinet-office.gov.uk">jessica.oleary@digital.cabinet-office.gov.uk</a>
+			</p>
+			<p>
+			Ben Andrews, product manager - <a href="mailto:ben.andrews@digital.cabinet-office.gov.uk">ben.andrews@digital.cabinet-office.gov.uk</a>
+			</p>
+			<p>
+			To escalate an issue about a production service outside of working hours, please use the escalation contact details you have been sent.
+			</p>
 
-		<table>
-			<tbody>
-				<tr>
-					<th>Classification</th>
-					<th>Example</th>
-					<th>In hours</th>
-					<th>Out of hours</th>
-				</tr>
-				<tr>
-					<th scope="row">P1<br/>Critical<br/>Incident</th>
-					<td>
-						<ul class="list list-bullet">
-							<li  class="font-xsmall">Applications are unavailable to end users due to a problem with our platform</li>
-							<li  class="font-xsmall">Serious security breach on the platform</li>
-							<li  class="font-xsmall">You can't make a critical fix to your production app due to the PaaS API not being available</li>
-							<li  class="font-xsmall">Your live production app has a P1 issue which cannot be resolved without help from us</li>
-						</ul>
-					</td>
-					<td>
-						<p class="font-xsmall">Start work &amp; respond: 20 minutes</p>
-						<p class="font-xsmall">Update time: 1hr</p>
-					</td>
-					<td>
-						<p class="font-xsmall">Start work &amp; respond: 40 minutes</p>
-						<p class="font-xsmall">Update time: 1hr</p>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">P2<br/>Major<br/>Incident</th>
-					<td>
-						<ul class="list list-bullet">
-							<li class="font-xsmall">Can&apos;t update/push apps due to platform issue</li>
-							<li class="font-xsmall">Upstream vulnerabilities in GOV.UK PaaS components</li>
-							<li class="font-xsmall">Elevated error rates on the GOV.UK PaaS platform</li>
-							<li class="font-xsmall">Complete failure of a GOV.UK PaaS component</li>
-							<li class="font-xsmall">Substantial degradation of the GOV.UK PaaS service</li>
-						</ul>
-					</td>
-					<td>
-						<p class="font-xsmall">Start work &amp; respond: 30 minutes</p>
-						<p class="font-xsmall">Update time: 2hr</p>
-					</td>
-					<td>
-						<p class="font-xsmall"></p>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">P3<br/>Significant<br/>issue</th>
-					<td>
-						<ul class="list list-bullet">
-							<li class="font-xsmall">Users (platform users or end users) experiencing intermittent or degraded service due to platform issue.</li>
-						</ul>
-					</td>
-					<td>
-						<p class="font-xsmall">Start work &amp; respond: 2 hours</p>
-						<p class="font-xsmall">Update time: 4 hours</p>
-					</td>
-					<td>
-						<p class="font-xsmall"></p>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">P4<br/>Minor<br/>issue</th>
-					<td>
-						<ul class="list list-bullet">
-							<li class="font-xsmall">Component failure that is not immediately impacting on service</li>
-						</ul>
-					</td>
-					<td>
-						<p class="font-xsmall">Start work &amp; respond: 1 business day</p>
-						<p class="font-xsmall">Update time: 2 business days</p>
-					</td>
-					<td>
-						<p class="font-xsmall"></p>
-					</td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
-	<div class="column-two-thirds">
+			<h2 class="heading-large">Updates and announcements</h2>
 
-		<p> Please do not share this email address with people outside of your team.  </p>
+			<p>
+			Use our <a href="https://status.cloud.service.gov.uk/">system status page</a> feed to sign up to get alerts and incident updates.
+			</p>
+			<p>
+			<a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a> to find out about new features and changes to the platform.
 
-		<h2 class="heading-large">Escalate support requests</h2>
-		<p> If we are not handling your request for support in the way you would expect, please contact a member of the product team, who will reply during working hours: </p>
-		<p> Tom Dolan, senior product manager - <a href="mailto:tom.dolan@digital.cabinet-office-gov.uk"> tom.dolan@digital.cabinet-office-gov.uk </a> <br /> Jess O'Leary, product manager - <a href="mailto:jessica.oleary@digital.cabinet-office.gov.uk"> jessica.oleary@digital.cabinet-office.gov.uk </a> </p>
-		<p> Outside of working hours, please use the escalation contact details you have been sent.</p>
-		<h2 class="heading-large">Updates and announcements</h2>
-		<p> Our <a href="https://status.cloud.service.gov.uk/">system status page</a> shows if live applications and databases are available. You can use this page to sign up to get alerts and incident updates.  </p>
-		<p> <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce">Join our announcements mailing list</a> to find out about new features and changes to the platform. If you have trouble signing up, please contact <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> and we will add you manually.  </p>
+			</p>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157390225
https://www.pivotaltracker.com/story/show/157390238

What?
----

We want a new page with our support and response time levels, and update
the support page to refer to it.

This PR actually implements two cards:

 - https://www.pivotaltracker.com/story/show/157390225
 - https://www.pivotaltracker.com/story/show/157390238

How to review?
------

 - Run it locally as described in the README
 - Compare with the proposed content in the docs

Notes
-----

The anchor in the new page does not work and I do not know why? because that  I disabled anchor link in same page:

The site has some kind of weird behaviour (some javascript?) with anchors. When referring an anchor, it gets stripped from the url. But with the anchor is in the same page, the client gets redirected
to the previous page (???).

I do not want to block the change so I disable the link for the time being.

maybe @carolinegreen can help here

Who?
---

Anyone but me