### PR TITLE
Top align table content, not centred

### DIFF
--- a/assets/stylesheets/_core.scss
+++ b/assets/stylesheets/_core.scss
@@ -166,3 +166,7 @@ legend {
 	margin: 15px 0 5px;
 	padding: 5px;
 }
+
+table th, table td {
+    vertical-align: top;
+}


### PR DESCRIPTION
Centred is browser default, but:
- it looks messier
- it makes it harder to scan across the table because stuff doesn’t line up

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/41236806-ee20f7e0-6d89-11e8-9f2d-5fc758ed5b1a.png) | ![image](https://user-images.githubusercontent.com/355079/41236792-e4399520-6d89-11e8-918a-b7e05e6cd1be.png)
