### PR TITLE
Updated link to tech docs "Get started"

### DIFF
--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -41,7 +41,7 @@
 
 			<h3 class="heading-medium">Push your first app</h3>
 			<p>
-				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/#quick-setup-guide">quick setup guide</a> will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.
+				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/#get-started">get started</a> guide will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.
 			</p>
 
 			<h3 class="heading-medium">Support in trial mode</h3>


### PR DESCRIPTION
Replaced obsolete "quick setup guide" link to tech docs with "Get started" link to tech docs. (https://docs.cloud.service.gov.uk/#get-started)