### PR TITLE
[#158489954] Increase the form message size to 50k

### DIFF
--- a/models/forms.rb
+++ b/models/forms.rb
@@ -5,10 +5,11 @@ module Forms
 
 	class GenericContact < Model
 		MAX_FIELD_LEN = 2048
+		MAX_MESSAGE_LEN = 50000
 
 		field :person_name,                  String, :required => true, :min => 2, :max => MAX_FIELD_LEN, :label => 'Name'
 		field :person_email,                 String, :required => true, :match => VALID_EMAIL_REGEX, :min => 5, :max => MAX_FIELD_LEN, :label => 'Email address'
-		field :message,                      String, :required => true, :max => MAX_FIELD_LEN, :min => 1, :label => 'Message'
+		field :message,                      String, :required => true, :max => MAX_MESSAGE_LEN, :min => 1, :label => 'Message'
 
 		def subject
 			"[PaaS Support] #{Date.today.to_s} support request from website"


### PR DESCRIPTION
What?
----

We want to allow the users to put more data than 2k in the message
field. We increase the max message length to 50000, as the
maximum comment size in ZenDesk is 64k[1] and we need space for
other info.

In a follow up story we should test this and add some feedback to
the user about the maximum size.

[1] https://support.zendesk.com/hc/en-us/articles/360000567348-Is-there-a-character-limit-on-ticket-comments-

How to review?
--------------

Code review

Who?
----

not me