### PR TITLE
Update links to tech docs

### DIFF
--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -46,7 +46,7 @@
 
 			<h3 class="heading-medium">Support in trial mode</h3>
 			<p>
-				Check the documentation to <a href="https://docs.cloud.service.gov.uk/troubleshooting.html#troubleshooting-2">troubleshoot common problems</a>. If you can’t find a solution our team can help during office hours. Contact us through our <a href="/support">support page</a>.
+				Check the documentation to <a href="https://docs.cloud.service.gov.uk/troubleshooting.html#troubleshooting">troubleshoot common problems</a>. If you can’t find a solution our team can help during office hours. Contact us through our <a href="/support">support page</a>.
 			</p>
 
 			<h3 class="heading-medium">Increase your quota</h3>

--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -31,22 +31,22 @@
 
 			<h3 class="heading-medium">Check the features</h3>
 			<p>
-				Make sure we currently support the <a href="https://docs.cloud.service.gov.uk/#paas-requirements">language, framework</a> and <a href="/features">backing services</a> you need. Our <a href="/roadmap">roadmap</a> lists the features planned for release in the coming months.
+				Make sure we currently support the <a href="https://docs.cloud.service.gov.uk/before_you_start.html#before-you-start">language, framework</a> and <a href="/features">backing services</a> you need. Our <a href="/roadmap">roadmap</a> lists the features planned for release in the coming months.
 			</p>
 
 			<h3 class="heading-medium">Request an account</h3>
 			<p>
-				When you <a href="/signup">request an account</a> you can invite as many team members as you need and choose the ones who’ll be in charge of managing users. They’ll be able to request more user accounts, including ones for external suppliers, and assign <a href="https://docs.cloud.service.gov.uk/#user-roles">roles and permissions</a>.
+				When you <a href="/signup">request an account</a> you can invite as many team members as you need and choose the ones who’ll be in charge of managing users. They’ll be able to request more user accounts, including ones for external suppliers, and assign <a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles">roles and permissions</a>.
 			</p>
 
 			<h3 class="heading-medium">Push your first app</h3>
 			<p>
-				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/#get-started">get started</a> guide will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.
+				Once we set up your account and you have <a href="https://docs.cloud.service.gov.uk/get_started.html#set-up-command-line">installed the Cloud Foundry CLI</a>, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our <a href="https://docs.cloud.service.gov.uk/get_started.html#get-started">get started</a> guide will help you deploy a static site to test your connection and then <a href="https://docs.cloud.service.gov.uk/deploying_apps.html#deploying-apps">push some sample code</a>, use the marketplace to <a href="https://docs.cloud.service.gov.uk/deploying_services.html#deploy-a-backing-or-routing-service">request backing services like databases</a>, and set up multiple environments and a development pipeline.
 			</p>
 
 			<h3 class="heading-medium">Support in trial mode</h3>
 			<p>
-				Check the documentation to <a href="https://docs.cloud.service.gov.uk/#troubleshooting">troubleshoot common problems</a>. If you can’t find a solution our team can help during office hours. Contact us through our <a href="/support">support page</a>.
+				Check the documentation to <a href="https://docs.cloud.service.gov.uk/troubleshooting.html#troubleshooting-2">troubleshoot common problems</a>. If you can’t find a solution our team can help during office hours. Contact us through our <a href="/support">support page</a>.
 			</p>
 
 			<h3 class="heading-medium">Increase your quota</h3>


### PR DESCRIPTION
Updated following links:

Check the features
Make sure we currently support the language, framework and backing services you need. Our roadmap lists the features planned for release in the coming months.

Request a trial account
When you request an account you can invite as many team members as you need and choose the ones who’ll be in charge of managing users. They’ll be able to request more user accounts, including ones for external suppliers, and assign roles and permissions.

Push your first app
Once we set up your account and you have installed the Cloud Foundry CLI, you can access GOV.UK PaaS, set a password and start using the platform straight away. Our get started guide will help you deploy a static site to test your connection and then push some sample code, use the marketplace to request backing services like databases, and set up multiple environments and a development pipeline.

Support in trial mode
Check the documentation to troubleshoot common problems If you can’t find a solution our team can help during office hours. Contact us through our support page.