### PR TITLE
Update link to tech docs

### DIFF
--- a/views/migrate-live-services.erb
+++ b/views/migrate-live-services.erb
@@ -28,7 +28,7 @@
 				Any migration typically involves switching costs. In the case of GOV.UK PaaS you should consider:
 
 				<ul class="list list-bullet">
-					<li>the features we offer and the <a href="https://docs.cloud.service.gov.uk/#paas-requirements">languages and frameworks</a> we currently support</li>
+					<li>the features we offer and the <a href="https://docs.cloud.service.gov.uk/before_you_start.html#before-you-start">languages and frameworks</a> we currently support</li>
 					<li>the releases planned in our <a href="/roadmap">roadmap</a> - bear in mind that we are always looking for private beta partners for new features</li>
 					<li>any work involved in making your applications follow the <a href="https://12factor.net/">12-factor app principles</a></li>
 					<li>the effort required to separate a monolithic service into components</li>


### PR DESCRIPTION
Updated following link:

Migrate a live service to GOV.UK PaaS
Any migration typically involves switching costs. In the case of GOV.UK PaaS you should consider:
- the features we offer and the languages and frameworks we currently support