### PR TITLE
Update links to tech docs

### DIFF
--- a/views/support-and-response-times.erb
+++ b/views/support-and-response-times.erb
@@ -15,7 +15,7 @@
 		<div class="column-two-thirds">
 			<h1 class="heading-xlarge">How we support the platform and our tenants</h1>
 			<p>
-			GOV.UK PaaS is supported 24 hours a day, 7 days a week by the team that builds it. Our <a href="https://docs.cloud.service.gov.uk/#responsibility-model">responsibility model</a> details the areas we cover.
+			GOV.UK PaaS is supported 24 hours a day, 7 days a week by the team that builds it. Our <a href="https://docs.cloud.service.gov.uk/guidance.html#responsibility-model">responsibility model</a> details the areas we cover.
 			</p>
 			<p>
 			You can email us for support at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>.


### PR DESCRIPTION
Update link to tech docs:

How we support the platform and our tenants
GOV.UK PaaS is supported 24 hours a day, 7 days a week by the team that builds it. Our responsibility model details the areas we cover.