### PR TITLE
Updated link to tech docs

### DIFF
--- a/views/pricing.erb
+++ b/views/pricing.erb
@@ -63,7 +63,7 @@
 				You have up to 3 months to decide whether GOV.UK PaaS is for you. At
 				the end of the trial period, if you want to keep using the platform
 				we’ll ask you to sign a memorandum of understanding - you’ll get access
-				to the full set of features and we’ll start billing you. 
+				to the full set of features and we’ll start billing you.
 			</p>
 			<p>
 				You will be charged monthly, based on the resources you use. Use our
@@ -76,7 +76,7 @@
 			<p>
 				If at the end of the trial period you decide that GOV.UK PaaS is not
 				the right solution for you, we will close your
-				<a href="https://docs.cloud.service.gov.uk/#organisations">organisation</a>
+				<a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html#organisations">organisation</a>
 				and all the user accounts associated to it.
 			</p>
 


### PR DESCRIPTION
Updated link to tech docs:

If at the end of the trial period you decide that GOV.UK PaaS is not the right solution for you, we will close your organisation and all the user accounts associated to it.