### PR TITLE
Upgrade rack to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.3)
       rack
     rack-test (0.7.0)


### PR DESCRIPTION
To fix CVE-2018-16470 [1].

[1]https://groups.google.com/forum/#!msg/rubyonrails-security/U_x-YkfuVTg/xhvYAmp6AAAJ