### PR TITLE
Add sign-in page and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+What
+----
+
+Describe what you have changed and why.
+
+How to review
+-------------
+
+Describe the steps required to test the changes.
+
+Who can review
+--------------
+
+Describe who can review the changes. Or more importantly, list the people
+that can't review, because they worked on it.

--- a/app.rb
+++ b/app.rb
@@ -129,6 +129,17 @@ class App < Sinatra::Base
 		end
 	end
 
+	post '/sign-in' do
+		case params[:region]
+		when 'london'
+			redirect('https://login.london.cloud.service.gov.uk/login', 302)
+		when 'ireland'
+			redirect('https://login.cloud.service.gov.uk/login', 302)
+		else
+			erb :'sign-in'
+		end
+	end
+
 	get '/support' do
 		@errors = {}
 		erb :'forms/support'

--- a/views/index.erb
+++ b/views/index.erb
@@ -26,7 +26,7 @@
 				</p>
 				<a href="/get-started" role="button" class="hero-button">
 					See how to get started
-				</a>
+        </a>
 			</div>
 			<div class="hero__aside-image">
 				<img src="/images/paas-top-image.png" alt="" role="presentation">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -68,8 +68,8 @@
 		<nav class="breadcrumbs" aria-label="Breadcrumbs">
 			<ol itemscope itemtype="http://schema.org/BreadcrumbList">
 				<li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-					<a href="https://www.gov.uk/service-toolkit#components" itemprop="item">
-						<span itemprop="name">Components</span>
+					<a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item">
+						<span itemprop="name">GOV.UK services</span>
 					</a>
 				</li>
 				<li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -34,7 +34,6 @@
 					</span>
 					<span class="header__title">
 						Platform as a Service
-						<span class="phase-banner">Beta</span>
 					</span>
 				</a>
 			</div>
@@ -51,7 +50,8 @@
 						'Features' => '/features',
 						'Pricing' => '/pricing',
 						'Documentation' => 'https://docs.cloud.service.gov.uk',
-						'Support' => '/support'
+						'Support' => '/support',
+						'Sign in' => '/sign-in',
 					}.each do |title, url| %>
 						<li<% if url == request.path_info %> class="active"<% end %>>
 							<a href="<%= url == request.path_info ? "#main" : url %>">

--- a/views/partials/_breadcrumb.erb
+++ b/views/partials/_breadcrumb.erb
@@ -1,5 +1,3 @@
 <li class="breadcrumbs__item <%= defined? active && active ? 'breadcrumbs__item--active' : '' %>" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-	<a href="<%= href || '#' %>" itemprop="item">
-		<span itemprop="name"><%= name %></span>
-	</a>
+  <span itemprop="name"><%= name %></span>
 </li>

--- a/views/sign-in.erb
+++ b/views/sign-in.erb
@@ -2,6 +2,10 @@
 	<title><%= settings.title %></title>
 <% end %>
 
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Sign in', href: request.path_info, active: true} %>
+<% end %>
+
 <div class="container">
 
 	<section class="content-section">

--- a/views/sign-in.erb
+++ b/views/sign-in.erb
@@ -1,0 +1,68 @@
+<% content_for :head do %>
+	<title><%= settings.title %></title>
+<% end %>
+
+<div class="container">
+
+	<section class="content-section">
+		<div class="grid-row">
+			<div class="column-full">
+        <form method="POST">
+          <div class="form-group">
+            <fieldset>
+              <legend>
+                <h1 class="heading-xlarge">Choose your region</h1>
+              </legend>
+
+              <div class="multiple-choice">
+                <input id="region-london"
+                       name="region"
+                       type="radio"
+                       checked
+                       value="london">
+                <label for="region-london">
+                  <span style="font-weight: 700;">London</span>
+                  <span class="form-hint">
+                  Apps without a custom domain end with
+                  <code>london.cloudapps.digital</code>.
+                  </span>
+                </label>
+              </div>
+
+              <div class="multiple-choice">
+                <input id="region-ireland"
+                       name="region"
+                       type="radio"
+                       value="ireland">
+                <label for="region-ireland">
+                  <span style="font-weight: 700;">Ireland</span>
+                  <span class="form-hint">
+                    Apps without a custom domain end with
+                    <code>cloudapps.digital</code>.
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+          </div>
+          <div class="form-group">
+            <button class="button">Continue</button>
+          </div>
+        </form>
+      </div>
+
+			<div class="column-full">
+        <h2 class="heading-large">
+          Use the Command Line
+        </h2>
+        <p class="content-section__body">
+          If you need help accessing GOV.UK PaaS from the
+          command-line interface, take a look at our
+          <a href="https://docs.cloud.service.gov.uk/get_started.html#set-up-the-cloud-foundry-command-line">technical
+        documentation</a>.
+				</p>
+      </div>
+
+		</div>
+	</section>
+
+</div>


### PR DESCRIPTION
What
----

- Adds PR template
- Adds sign-in (to PaaSmin) page and links to it from Hero

Screenshots
---

![screencapture-localhost-9292-2019-05-06-22_06_05](https://user-images.githubusercontent.com/1482692/57255276-48568a80-704b-11e9-88a9-59a839174bd2.png)
*"sign in" link on home-page Hero; note: "Sign in" is not a nav link*

![image](https://user-images.githubusercontent.com/1482692/57255391-818efa80-704b-11e9-9d2b-1a53f256f129.png)
*`/sign-in` page (linked to from above)*

How to review
-------------

Code review

Spin it up locally

Who can review
--------------

Not @tlwr