### PR TITLE
Change sign-in link to point to paas-admin

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -132,9 +132,9 @@ class App < Sinatra::Base
 	post '/sign-in' do
 		case params[:region]
 		when 'london'
-			redirect('https://login.london.cloud.service.gov.uk/login', 302)
+			redirect('https://admin.london.cloud.service.gov.uk/', 302)
 		when 'ireland'
-			redirect('https://login.cloud.service.gov.uk/login', 302)
+			redirect('https://admin.cloud.service.gov.uk/', 302)
 		else
 			erb :'sign-in'
 		end


### PR DESCRIPTION
What
----

This means that when users who are already logged in click on the
sign-in link, then they will not see a login page but immediately see
the portal.

How to review
-------------

Code review

Put the links in your browser

Who can review
--------------

Not @tlwr