### PR TITLE
Removed escalation contact details from this form

### DIFF
--- a/views/forms/something-wrong-with-service.erb
+++ b/views/forms/something-wrong-with-service.erb
@@ -81,11 +81,6 @@
 					<button id="submit" class="button" type="submit">Submit</button>
 				</div>
 			</form>
-			<h2 class="heading-medium">Escalate a request</h2>
-			<p>If you have already sent your request for support, and you think we’re not handling it in the way you would expect, please contact a member of the product team, who will reply during working hours:</p>
-			<p>James Whitmarsh, product manager: <a href="mailto:james.whitmarsh@digital.cabinet-office.gov.uk">james.whitmarsh@digital.cabinet-office.gov.uk</a></p>
-			<p>Ben Andrews, product manager: <a href="mailto:ben.andrews@digital.cabinet-office.gov.uk">ben.andrews@digital.cabinet-office.gov.uk</a></p>
-			<p>To escalate an issue about a production service outside of working hours, please use the escalation contact details you have been sent.</p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
What
----

I removed the escalation contact details from this form because
a) the details refer to people to no longer work on GOV.UK PaaS
b) We are changing our escalation process 

How to review
-------------

Check me removing this doesn't break the form 

Who can review
--------------

Anyone who isn't Luke Malcher
