### PR TITLE
BAU - fonts look fugly in Firefox without this

### DIFF
--- a/assets/stylesheets/_core.scss
+++ b/assets/stylesheets/_core.scss
@@ -60,6 +60,7 @@ html {
 html, body {
 	margin: 0;
 	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	@include core-19;
 }
 


### PR DESCRIPTION
## Before

![Screenshot_2019-07-02 GOV UK Platform as a Service](https://user-images.githubusercontent.com/440503/60526020-68bb6200-9ce7-11e9-8154-399a9a4be521.png)

## After
![Screenshot_2019-07-02 GOV UK Platform as a Service(1)](https://user-images.githubusercontent.com/440503/60526069-825ca980-9ce7-11e9-91d1-0d82d0bb6812.png)
