### PR TITLE
Allow nhs.net emails as well as .gov.uk ones

### DIFF
--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -95,7 +95,7 @@ $(function(){
 	}
 
 	function isGovEmail(v) {
-		return v && /.+\.gov\.uk$/.test(v);
+		return v && (/.+\.gov\.uk$/.test(v) || /.+nhs\.net$/.test(v));
 	}
 
 	function getFormError(name, value) {
@@ -113,7 +113,7 @@ $(function(){
 				return 'Must be a valid email address';
 			}
 			if (!isGovEmail(value)) {
-				return 'We can only accept requests from .gov.uk email addresses';
+				return 'We can only accept requests from .gov.uk or nhs.net email addresses';
 			}
 		} else if (name == 'department_name') {
 			if (isBlank(value)) {

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -63,7 +63,7 @@ module Forms
 		field :message,                      String, :required => false # Make message optional
 
 		# Ensure the email is .gov.uk
-        field :person_email,                 String, :required => true, :match => /.+@.+\.gov\.uk$/, :min => 5, :label => 'Email address'
+		field :person_email,                 String, :required => true, :match => /.+@.+(?:\.gov\.uk|\.nhs\.net)$/, :min => 5, :label => 'Email address'
 
 		field :person_is_manager,            Boolean
 		field :department_name,              String, :required => true

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Signup", :type => :feature do
 
 	include Rack::Test::Methods
 
-	it "should submit the form successfully" do
+  it "should submit the form successfully with gov.uk email" do
 		visit '/signup'
 		fill_in('person_name', with: 'Jeff Jefferson')
 		fill_in('person_email', with: 'jeff@test.gov.uk')
@@ -46,6 +46,45 @@ RSpec.describe "Signup", :type => :feature do
 		}
 	end
 
+  it "should submit the form successfully with nhs.net email" do
+		visit '/signup'
+		fill_in('person_name', with: 'Jane Janedóttir')
+    fill_in('person_email', with: 'jane@test.nhs.net')
+		fill_in('department_name', with: 'TestDept')
+		fill_in('service_name', with: 'TestService')
+		find('input#person_is_manager-0.toggle-radio-note').set(true)
+		click_button('signup-submit')
+		all('.error-message').each do |err|
+			expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
+		end
+		all('.error-summary .err').each do |err|
+			expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
+		end
+		expect(page.status_code).to eq(200)
+
+		expect(WebMock).to have_requested(
+			:post, "#{ENV['ZENDESK_URL']}/tickets"
+		).once.with{|req|
+			data = JSON.parse(req.body)
+			expect(data).to include("ticket")
+			expect(data["ticket"]).to include("subject")
+			expect(data["ticket"]["subject"]).to match(/\[PaaS Support\] .* Registration Request/)
+			expect(data["ticket"]).to include("requester" => {"email"=>"jane@test.nhs.net", "name"=>"Jane Janedóttir"})
+			expect(data["ticket"]).to include("group_id" => ENV['ZENDESK_GROUP_ID'].to_i)
+			expect(data["ticket"]).to include("tags")
+			expect(data["ticket"]["tags"]).to include("govuk_paas_support")
+			expect(data["ticket"]["tags"]).to include("govuk_paas_product_page")
+
+			expect(data["ticket"]).to include("comment")
+			expect(data["ticket"]["comment"]).to include("body")
+			expect(data["ticket"]["comment"]["body"]).to include("From: Jane Janedóttir")
+			expect(data["ticket"]["comment"]["body"]).to include("Email: jane@test.nhs.net")
+			expect(data["ticket"]["comment"]["body"]).to include("Department: TestDept")
+			expect(data["ticket"]["comment"]["body"]).to include("Team/Service: TestService")
+			expect(data["ticket"]["comment"]["body"]).to include("They would also like to invite")
+		}
+	end
+
 	it "should require person_name field" do
 		visit '/signup'
 		fill_in('person_email', with: 'jeff@test.gov.uk')
@@ -77,7 +116,7 @@ RSpec.describe "Signup", :type => :feature do
 		expect(page.status_code).to eq(400)
 	end
 
-	it "should require a .gov.uk email for person_email" do
+  it "should require a .gov.uk or .nhs.net email for person_email" do
 		visit '/signup'
 		fill_in('person_name', with: 'jeff')
 		fill_in('person_email', with: 'jeff@gmail.com')


### PR DESCRIPTION
What
----

Raised in https://govuk.zendesk.com/agent/tickets/3721988

This isn't strictly needed since we can create organisations for NHS
people without using the form already. But there's no need to exclude
them from the normal process since we've got a non-crown contract now.

How to review
-------------

* Code review
* Check the tests pass
* Check out this screenshot

![image](https://user-images.githubusercontent.com/1696784/61461435-94398000-a968-11e9-9e23-7ca785de63c3.png)


Who can review
--------------

Not @richardtowers