### PR TITLE
Fix incorrectly closed li causing spurious bullet

### DIFF
--- a/views/get-started.erb
+++ b/views/get-started.erb
@@ -59,7 +59,7 @@
 			</p>
 			<ul class="list list-bullet">
 			<li><a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles">add a Billing Manager to your GOV.UK PaaS organisation</a>, who can authorise and manage payment for the service</li>
-			<li>email <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to request the upgrade, copying in your Billing Manager<li/>	
+			<li>email <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> to request the upgrade, copying in your Billing Manager</li>	
 			</ul>
 
 			<a class="button" href="/signup">Request an account</a>


### PR DESCRIPTION
What
----

Fixed the closing li at the end of the Get Started page

How to review
-------------

Review before/after of the last block of text before the `Request an account` button

Who can review
--------------

Anyone except me! I'm not GDS or gov :)