### PR TITLE
[#166285256] Add Microsoft & Google SSO to product pages

### DIFF
--- a/views/features.erb
+++ b/views/features.erb
@@ -33,6 +33,7 @@
 				<li>Applications running on the platform are isolated from each other so they can’t read or change each other's code, data or logs</li>
 				<li>Applications can communicate internally via a private network</li>
 				<li>Authorised developers have SSH access to application containers to debug problems</li>
+				<li>It supports single sign-on for through your organisation's Microsoft or Google accounts</li>
 			</ul>
 			<p class="content-section__body">
 				<a href="/security">Read more about how we keep GOV.UK PaaS secure</a>

--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -22,14 +22,10 @@
 			<ul class="list list-bullet">
 				<li>S3 object storage</li>
 				<li>Non-crown offering</li>
-			</ul>
-			
-			<h2 class="heading-medium">What we're working on now</h2> 
-			<ul class="list list-bullet">
 				<li>Support for Google and Microsoft single-sign on</li>
 			</ul>
 
-			<h2 class="heading-medium">What we're working on next (next 3 to 6 months)</h2>
+			<h2 class="heading-medium">What we're working on next</h2>
 			<ul class="list list-bullet">
 				<li>Logging and metrics "out of the box"</li>
 				<li>Tenant tools for secrets management</li>

--- a/views/security.erb
+++ b/views/security.erb
@@ -29,6 +29,7 @@
 				<li>Linux containers provide the boundary between running application instances</li>
 				<li>the platform relies on robust operational security and processes (see below)</li>
 				<li>it’s possible to change and revoke your team members’ permissions and roles to manage the service</li>
+				<li>users can authenticate via single sign-on with your organisation's Google and Microsoft accounts</li>
 				<li>we use 2-factor authentication, short-lived credentials and IP restriction policies for identity and access management to protect AWS resources</li>
 				<li>shared credentials are rotated to minimise risk of unauthorised access</li>
 				<li>Amazon Cloudtrail audits and monitors AWS activity</li>


### PR DESCRIPTION
What
----
Adds mentions of Microsoft and Google SSO in the relevant places in the tech docs

How to review
-------------
Copy review

Who can review
--------------
Anyone. Some 👀from @jonathanglassman re: style would be helpful.
