### PR TITLE
Allow both nhs.uk and nhs.net email addresses

### DIFF
--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -95,7 +95,7 @@ $(function(){
 	}
 
 	function isGovEmail(v) {
-		return v && (/.+\.gov\.uk$/.test(v) || /.+nhs\.net$/.test(v));
+		return v && (/.+\.gov\.uk$/.test(v) || /.+nhs\.(net|uk)$/.test(v));
 	}
 
 	function getFormError(name, value) {
@@ -113,7 +113,7 @@ $(function(){
 				return 'Must be a valid email address';
 			}
 			if (!isGovEmail(value)) {
-				return 'We can only accept requests from .gov.uk or nhs.net email addresses';
+				return 'We can only accept requests from .gov.uk, nhs.net, or nhs.uk email addresses';
 			}
 		} else if (name == 'department_name') {
 			if (isBlank(value)) {

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -63,7 +63,7 @@ module Forms
 		field :message,                      String, :required => false # Make message optional
 
 		# Ensure the email is .gov.uk
-		field :person_email,                 String, :required => true, :match => /.+@.+(?:\.gov\.uk|\.nhs\.net)$/, :min => 5, :label => 'Email address'
+    field :person_email,                 String, :required => true, :match => /.+@(?:.+\.gov\.uk|.*(nhs\.(net|uk)))$/, :min => 5, :label => 'Email address'
 
 		field :person_is_manager,            Boolean
 		field :department_name,              String, :required => true

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -46,43 +46,48 @@ RSpec.describe "Signup", :type => :feature do
 		}
 	end
 
-  it "should submit the form successfully with nhs.net email" do
-		visit '/signup'
-		fill_in('person_name', with: 'Jane Janedóttir')
-    fill_in('person_email', with: 'jane@test.nhs.net')
-		fill_in('department_name', with: 'TestDept')
-		fill_in('service_name', with: 'TestService')
-		find('input#person_is_manager-0.toggle-radio-note').set(true)
-		click_button('signup-submit')
-		all('.error-message').each do |err|
-			expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
-		end
-		all('.error-summary .err').each do |err|
-			expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
-		end
-		expect(page.status_code).to eq(200)
+  %w(net uk).each do |tld|
+    it "should submit the form successfully with an nhs.#{tld} email" do
+      email = "jane@nhs.#{tld}"
 
-		expect(WebMock).to have_requested(
-			:post, "#{ENV['ZENDESK_URL']}/tickets"
-		).once.with{|req|
-			data = JSON.parse(req.body)
-			expect(data).to include("ticket")
-			expect(data["ticket"]).to include("subject")
-			expect(data["ticket"]["subject"]).to match(/\[PaaS Support\] .* Registration Request/)
-			expect(data["ticket"]).to include("requester" => {"email"=>"jane@test.nhs.net", "name"=>"Jane Janedóttir"})
-			expect(data["ticket"]).to include("group_id" => ENV['ZENDESK_GROUP_ID'].to_i)
-			expect(data["ticket"]).to include("tags")
-			expect(data["ticket"]["tags"]).to include("govuk_paas_support")
-			expect(data["ticket"]["tags"]).to include("govuk_paas_product_page")
+      visit '/signup'
+      fill_in('person_name', with: 'Jane Janedóttir')
+      fill_in('person_email', with: email)
+      fill_in('department_name', with: 'TestDept')
+      fill_in('service_name', with: 'TestService')
+      find('input#person_is_manager-0.toggle-radio-note').set(true)
+      click_button('signup-submit')
+      all('.error-message').each do |err|
+        expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
+      end
+      all('.error-summary .err').each do |err|
+        expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
+      end
+      expect(page.status_code).to eq(200)
 
-			expect(data["ticket"]).to include("comment")
-			expect(data["ticket"]["comment"]).to include("body")
-			expect(data["ticket"]["comment"]["body"]).to include("From: Jane Janedóttir")
-			expect(data["ticket"]["comment"]["body"]).to include("Email: jane@test.nhs.net")
-			expect(data["ticket"]["comment"]["body"]).to include("Department: TestDept")
-			expect(data["ticket"]["comment"]["body"]).to include("Team/Service: TestService")
-			expect(data["ticket"]["comment"]["body"]).to include("They would also like to invite")
-		}
+      expect(WebMock).to have_requested(
+        :post, "#{ENV['ZENDESK_URL']}/tickets"
+      ).once.with{|req|
+        data = JSON.parse(req.body)
+        expect(data).to include("ticket")
+        expect(data["ticket"]).to include("subject")
+        expect(data["ticket"]["subject"]).to match(/\[PaaS Support\] .* Registration Request/)
+        expect(data["ticket"]).to include("requester" => {"email"=>email, "name"=>"Jane Janedóttir"})
+        expect(data["ticket"]).to include("group_id" => ENV['ZENDESK_GROUP_ID'].to_i)
+        expect(data["ticket"]).to include("tags")
+        expect(data["ticket"]["tags"]).to include("govuk_paas_support")
+        expect(data["ticket"]["tags"]).to include("govuk_paas_product_page")
+
+        expect(data["ticket"]).to include("comment")
+        expect(data["ticket"]["comment"]).to include("body")
+        expect(data["ticket"]["comment"]["body"]).to include("From: Jane Janedóttir")
+        expect(data["ticket"]["comment"]["body"]).to match(/Email: jane@nhs.(uk|net)/)
+        expect(data["ticket"]["comment"]["body"]).to include("Email: #{email}")
+        expect(data["ticket"]["comment"]["body"]).to include("Department: TestDept")
+        expect(data["ticket"]["comment"]["body"]).to include("Team/Service: TestService")
+        expect(data["ticket"]["comment"]["body"]).to include("They would also like to invite")
+      }
+    end
 	end
 
 	it "should require person_name field" do


### PR DESCRIPTION
What
----

Our dearest colleagues at the NHS have both `foo.nhs.net` emails and `bar@nhs.uk` emails

We should allow them to sign up the normal way

How to review
-------------

Code review

Run ze tests

Who can review
--------------

@richardTowers as he did this the last time