### PR TITLE
Fix typo on pricing.erb

### DIFF
--- a/views/pricing.erb
+++ b/views/pricing.erb
@@ -46,7 +46,7 @@
 				included in this price are:
 			</p>
 			<ul class="list list-bullet">
-				<li>as many <a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html">users or organisations</a>as you need</li>
+				<li>as many <a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html">users or organisations</a> as you need</li>
 				<li>access to our all our <a href="/support-and-response-times">support channels</a>, including 24/7 support for live services</li> 
 				<li>a user friendly administration tool for managing your organisations, users, applications and billing</li>
 				<li>full access to all the <a href="/features">features of the platform</a></li>  


### PR DESCRIPTION
What
----

There was a missing space in the sentence "as many users or organisations as you need". I've put the space in.

How to review
-------------

Check the space is there now
Test none of the html is broken by the change

Who can review
--------------

Anyone that's not JakeMcCann
