### PR TITLE
Clarify personnel security rules

### DIFF
--- a/views/cloud-security-principles.erb
+++ b/views/cloud-security-principles.erb
@@ -148,7 +148,7 @@
 				<li>GOV.UK PaaS team onboarding</li>
 			</ul>
 
-			<p>GDS follows government and Cabinet Office personnel security processes. All GDS personnel must have at least a security clearance of Security Checked (SC).</p>
+			<p>GDS follows government and Cabinet Office personnel security processes. All GDS personnel must pass a Baseline Personnel Security Standard (BPSS) check. Personnel with access to production systems must have at least a security clearance of Security Checked (SC).</p>
 
 			<p>Before GDS personnel can access production environments, their team leads and senior management assess that personnel’s technical competence and adherence to agreed team working practices.</p>
 

--- a/views/cloud-security-principles.erb
+++ b/views/cloud-security-principles.erb
@@ -148,7 +148,7 @@
 				<li>GOV.UK PaaS team onboarding</li>
 			</ul>
 
-			<p>GDS follows government and Cabinet Office personnel security processes. All GDS personnel must pass a Baseline Personnel Security Standard (BPSS) check. Personnel with access to production systems must have at least a security clearance of Security Checked (SC).</p>
+			<p>GDS follows government and Cabinet Office personnel security processes. All GDS personnel with access to production systems must have at least a security clearance of Security Checked (SC).</p>
 
 			<p>Before GDS personnel can access production environments, their team leads and senior management assess that personnel’s technical competence and adherence to agreed team working practices.</p>
 


### PR DESCRIPTION
What
----

The old wording implied that nobody could work for GDS without SC, but we routinely have people join before their clearance comes through. I think it's fair to say (at least for the paas team) that everyone's passed a BPSS check, and we don't give people access to prod until they've got SC.

How to review
-------------

* Check the change is accurate

Who can review
--------------

Not @richardTowers 
