### PR TITLE
New Police.uk email domain

### DIFF
--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -95,7 +95,7 @@ $(function(){
 	}
 
 	function isGovEmail(v) {
-		return v && (/.+\.gov\.uk$/.test(v) || /.+nhs\.(net|uk)$/.test(v) || /.+mod\.uk$/.test(v) || /.+\.police\.uk$/.test(v));
+		return v && (/.+\.gov\.uk$/.test(v) || /.+nhs\.(net|uk)$/.test(v) || /.+mod\.uk$/.test(v) || /.+\.police\.uk$/.test(v) || /police\.uk$/.test(v));
 	}
 
 	function getFormError(name, value) {
@@ -113,7 +113,7 @@ $(function(){
 				return 'Must be a valid email address';
 			}
 			if (!isGovEmail(value)) {
-				return 'We can only accept requests from .gov.uk, .mod.uk, nhs.net, nhs.uk or .police.uk email addresses';
+				return 'We can only accept requests from .gov.uk, .mod.uk, nhs.net, nhs.uk, .police.uk or police.uk email addresses';
 			}
 		} else if (name == 'department_name') {
 			if (isBlank(value)) {

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -63,7 +63,7 @@ module Forms
 		field :message,                      String, :required => false # Make message optional
 
 		# Ensure the email is .gov.uk
-		field :person_email,                 String, :required => true, :match => /.+@(?:.+\.gov\.uk|.*mod\.uk|.+\.police\.uk|.*(nhs\.(net|uk)))$/, :min => 5, :label => 'Email address'
+		field :person_email,                 String, :required => true, :match => /.+@(?:.+\.gov\.uk|.*mod\.uk|.+\.police\.uk|police\.uk|.*(nhs\.(net|uk)))$/, :min => 5, :label => 'Email address'
 
 		field :person_is_manager,            Boolean
 		field :department_name,              String, :required => true

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -60,10 +60,31 @@ module Forms
 	end
 
 	class Signup < GenericContact
+
+    VALID_GOV_DOMAIN_REGEX = Regexp.union(
+      # GOV.UK and nested subdomains
+      /[^@]+@gov[.]uk$/,
+      /[^@]+@[-.a-z0-9]+[.]gov[.]uk$/,
+
+      # MoD and nested subdomains
+      /[^@]+@mod[.]uk$/,
+      /[^@]+@[-.a-z0-9]+[.]mod[.]uk$/,
+
+      # Police and nested subdomains
+      /[^@]+@police[.]uk$/,
+      /[^@]+@[-.a-z0-9]+[.]police[.]uk$/,
+
+      # NHS and nested subdomains
+      /[^@]+@nhs[.]uk$/,
+      /[^@]+@[-.a-z0-9]+[.]nhs[.]uk$/,
+      /[^@]+@nhs[.]net$/,
+      /[^@]+@[-.a-z0-9]+[.]nhs[.]net$/,
+    )
+
 		field :message,                      String, :required => false # Make message optional
 
 		# Ensure the email is .gov.uk
-		field :person_email,                 String, :required => true, :match => /.+@(?:.+\.gov\.uk|.*mod\.uk|.+\.police\.uk|police\.uk|.*(nhs\.(net|uk)))$/, :min => 5, :label => 'Email address'
+		field :person_email,                 String, :required => true, :match => VALID_GOV_DOMAIN_REGEX, :min => 5, :label => 'Email address'
 
 		field :person_is_manager,            Boolean
 		field :department_name,              String, :required => true

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Signup", :type => :feature do
 		expect(page.status_code).to eq(400)
 	end
 
-  it "should require a .gov.uk or .nhs.net email for person_email" do
+  it "should reject users with a person_email not on our list" do
 		visit '/signup'
 		fill_in('person_name', with: 'jeff')
 		fill_in('person_email', with: 'jeff@gmail.com')

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -132,16 +132,18 @@ RSpec.describe "Signup", :type => :feature do
 		expect(page.status_code).to eq(400)
 	end
 
-  it "should require a @location.police.uk or @police.uk email for person_email" do
-		visit '/signup'
-		fill_in('person_name', with: 'jeff')
-		fill_in('person_email', with: 'jeff@notthepolice.uk')
-		fill_in('department_name', with: 'TestDept')
-		fill_in('service_name', with: 'TestService')
-		click_button('signup-submit')
-		expect(page.first('.form-group--person_email .error-message').text).not_to be_empty
-		expect(page.status_code).to eq(400)
-	end
+  %w(gov.uk nhs.net nhs.uk mod.uk police.uk).each do |tld|
+    it "should reject partial person_email matches for #{tld}" do
+      visit '/signup'
+      fill_in('person_name', with: 'jeff')
+      fill_in('person_email', with: "jeff@notthe#{tld}")
+      fill_in('department_name', with: 'TestDept')
+      fill_in('service_name', with: 'TestService')
+      click_button('signup-submit')
+      expect(page.status_code).to eq(400)
+      expect(page.first('.form-group--person_email .error-message').text).not_to be_empty
+    end
+  end
 
 	it "should require department_name field" do
 		visit '/signup'

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -47,46 +47,46 @@ RSpec.describe "Signup", :type => :feature do
 	end
 
   %w(nhs.net nhs.uk mod.uk met.police.uk police.uk).each do |tld|
-    it "should submit the form successfully with an #{tld} email" do
-      email = "jane@#{tld}"
+    ['subdomain.', ''].each do |prefix|
+      email = "jane@#{prefix}#{tld}"
+      it "should submit the form successfully with #{email}" do
+        visit '/signup'
+        fill_in('person_name', with: 'Jane Janedóttir')
+        fill_in('person_email', with: email)
+        fill_in('department_name', with: 'TestDept')
+        fill_in('service_name', with: 'TestService')
+        find('input#person_is_manager-0.toggle-radio-note').set(true)
+        click_button('signup-submit')
+        all('.error-message').each do |err|
+          expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
+        end
+        all('.error-summary .err').each do |err|
+          expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
+        end
+        expect(page.status_code).to eq(200)
 
-      visit '/signup'
-      fill_in('person_name', with: 'Jane Janedóttir')
-      fill_in('person_email', with: email)
-      fill_in('department_name', with: 'TestDept')
-      fill_in('service_name', with: 'TestService')
-      find('input#person_is_manager-0.toggle-radio-note').set(true)
-      click_button('signup-submit')
-      all('.error-message').each do |err|
-        expect(err.text).to be_empty, "Did not expect to see any validation errors but got: #{err.text}"
+        expect(WebMock).to have_requested(
+          :post, "#{ENV['ZENDESK_URL']}/tickets"
+        ).once.with{|req|
+          data = JSON.parse(req.body)
+          expect(data).to include("ticket")
+          expect(data["ticket"]).to include("subject")
+          expect(data["ticket"]["subject"]).to match(/\[PaaS Support\] .* Registration Request/)
+          expect(data["ticket"]).to include("requester" => {"email"=>email, "name"=>"Jane Janedóttir"})
+          expect(data["ticket"]).to include("group_id" => ENV['ZENDESK_GROUP_ID'].to_i)
+          expect(data["ticket"]).to include("tags")
+          expect(data["ticket"]["tags"]).to include("govuk_paas_support")
+          expect(data["ticket"]["tags"]).to include("govuk_paas_product_page")
+
+          expect(data["ticket"]).to include("comment")
+          expect(data["ticket"]["comment"]).to include("body")
+          expect(data["ticket"]["comment"]["body"]).to include("From: Jane Janedóttir")
+          expect(data["ticket"]["comment"]["body"]).to include("Email: #{email}")
+          expect(data["ticket"]["comment"]["body"]).to include("Department: TestDept")
+          expect(data["ticket"]["comment"]["body"]).to include("Team/Service: TestService")
+          expect(data["ticket"]["comment"]["body"]).to include("They would also like to invite")
+        }
       end
-      all('.error-summary .err').each do |err|
-        expect(err.text).to be_empty, "Did not expect to see a summary of errors but got: #{err.text}"
-      end
-      expect(page.status_code).to eq(200)
-
-      expect(WebMock).to have_requested(
-        :post, "#{ENV['ZENDESK_URL']}/tickets"
-      ).once.with{|req|
-        data = JSON.parse(req.body)
-        expect(data).to include("ticket")
-        expect(data["ticket"]).to include("subject")
-        expect(data["ticket"]["subject"]).to match(/\[PaaS Support\] .* Registration Request/)
-        expect(data["ticket"]).to include("requester" => {"email"=>email, "name"=>"Jane Janedóttir"})
-        expect(data["ticket"]).to include("group_id" => ENV['ZENDESK_GROUP_ID'].to_i)
-        expect(data["ticket"]).to include("tags")
-        expect(data["ticket"]["tags"]).to include("govuk_paas_support")
-        expect(data["ticket"]["tags"]).to include("govuk_paas_product_page")
-
-        expect(data["ticket"]).to include("comment")
-        expect(data["ticket"]["comment"]).to include("body")
-        expect(data["ticket"]["comment"]["body"]).to include("From: Jane Janedóttir")
-        expect(data["ticket"]["comment"]["body"]).to match(/Email: jane@#{tld}/)
-        expect(data["ticket"]["comment"]["body"]).to include("Email: #{email}")
-        expect(data["ticket"]["comment"]["body"]).to include("Department: TestDept")
-        expect(data["ticket"]["comment"]["body"]).to include("Team/Service: TestService")
-        expect(data["ticket"]["comment"]["body"]).to include("They would also like to invite")
-      }
     end
 	end
 
@@ -137,6 +137,17 @@ RSpec.describe "Signup", :type => :feature do
       visit '/signup'
       fill_in('person_name', with: 'jeff')
       fill_in('person_email', with: "jeff@notthe#{tld}")
+      fill_in('department_name', with: 'TestDept')
+      fill_in('service_name', with: 'TestService')
+      click_button('signup-submit')
+      expect(page.status_code).to eq(400)
+      expect(page.first('.form-group--person_email .error-message').text).not_to be_empty
+    end
+
+    it "should reject partial person_email matches for subdomains of #{tld}" do
+      visit '/signup'
+      fill_in('person_name', with: 'jeff')
+      fill_in('person_email', with: "jeff@subdomain.notthe#{tld}")
       fill_in('department_name', with: 'TestDept')
       fill_in('service_name', with: 'TestService')
       click_button('signup-submit')

--- a/spec/signup_spec.rb
+++ b/spec/signup_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Signup", :type => :feature do
 		}
 	end
 
-  %w(nhs.net nhs.uk mod.uk met.police.uk).each do |tld|
+  %w(nhs.net nhs.uk mod.uk met.police.uk police.uk).each do |tld|
     it "should submit the form successfully with an #{tld} email" do
       email = "jane@#{tld}"
 
@@ -125,6 +125,17 @@ RSpec.describe "Signup", :type => :feature do
 		visit '/signup'
 		fill_in('person_name', with: 'jeff')
 		fill_in('person_email', with: 'jeff@gmail.com')
+		fill_in('department_name', with: 'TestDept')
+		fill_in('service_name', with: 'TestService')
+		click_button('signup-submit')
+		expect(page.first('.form-group--person_email .error-message').text).not_to be_empty
+		expect(page.status_code).to eq(400)
+	end
+
+  it "should require a @location.police.uk or @police.uk email for person_email" do
+		visit '/signup'
+		fill_in('person_name', with: 'jeff')
+		fill_in('person_email', with: 'jeff@notthepolice.uk')
 		fill_in('department_name', with: 'TestDept')
 		fill_in('service_name', with: 'TestService')
 		click_button('signup-submit')


### PR DESCRIPTION
What
----

There is a plan to move all police email address to fall under one domain (police.uk). This commit ensures that these domains are valid for submitting whilst ensuring that we reject non police domains.

How to review
-------------

Code review and check the tests pass

Who can review
--------------

Anyone, but possibly @AP-Hunt due to prior context