### PR TITLE
Make feature headings linkable by adding id attrs

### DIFF
--- a/views/features.erb
+++ b/views/features.erb
@@ -15,8 +15,8 @@
 
 
 		<div class="column-two-thirds">
-			<h1 class="heading-xlarge">Features</h1>
-			<h2 class="heading-medium">The basics</h2>
+			<h1 id="features" class="heading-xlarge">Features</h1>
+			<h2 id="the-basics" class="heading-medium">The basics</h2>
 			<ul class="list list-bullet">
 				<li>UK hosted, with hosting in Ireland also available</li>
 				<li>runs from Amazon Web Services</li>
@@ -25,7 +25,7 @@
 				<li>you can decide to move to other Cloud Foundry-based PaaS providers, including on GCloud, as you’re not locked into our platform</li>
 				<li>it's best suited for <a href="https://12factor.net/">Twelve-Factor</a> App development</li>
 			</ul>
-			<h2 class="heading-medium">Security</h2>
+			<h2 id="security" class="heading-medium">Security</h2>
 			<ul class="list list-bullet">
 				<li>it’s accredited for handling personal and confidential information classified as Official</li>
 				<li>modern TLS standards are enforced for all traffic entering the platform</li>
@@ -38,7 +38,7 @@
 			<p class="content-section__body">
 				<a href="/security">Read more about how we keep GOV.UK PaaS secure</a>
 			</p>
-			<h2 class="heading-medium">Languages supported</h2>
+			<h2 id="languages-supported" class="heading-medium">Languages supported</h2>
 			<ul class="list list-bullet">
 				<li>Go</li>
 				<li>Node.js</li>
@@ -52,7 +52,7 @@
 				<li>R</li>
 			</ul>
 			<p>GOV.UK PaaS allows the use of custom buildpacks and Docker images (with limited functionality) to enable other technologies. Keep in mind that we can provide limited support for the maintenance of custom libraries and frameworks.</p>
-			<h2 class="heading-medium">Backing services</h2>
+			<h2 id="backing-services" class="heading-medium">Backing services</h2>
 			<ul class="list list-bullet">
 				<li>PostgreSQL</li>
 				<li>Redis</li>
@@ -61,14 +61,14 @@
 				<li>S3</li>
 			</ul>
 
-			<h2 class="heading-medium">Self-service Provisioning</h2>
+			<h2 id="self-service-provisioning" class="heading-medium">Self-service Provisioning</h2>
 			<ul class="list list-bullet">
 				<li>it takes a few minutes to create sandbox and testing environments, and even less to delete them once you don’t need them anymore</li>
 				<li>set up a new DB or service in minutes with the CloudFoundry command line or an API: no tickets or requests required</li>
 				<li>service teams can grow their service from prototype to production without replatforming</li>
 				<li>a pricing calculator is available to anticipate ongoing costs, and to assist with planning for scaling apps</li>
 			</ul>
-			<h2 class="heading-medium">Deploying and running apps</h2>
+			<h2 id="deploying-and-running-apps" class="heading-medium">Deploying and running apps</h2>
 			<ul class="list list-bullet">
 				<li>manage applications with the CloudFoundry command line or API</li>
 				<li>scale applications up and down in seconds</li>
@@ -77,14 +77,14 @@
 				<li>deploy from CI services such as Travis, Jenkins or Concourse</li>
 				<li>use a custom domain to host your app</li>
 			</ul>
-			<h2 class="heading-medium">Performance</h2>
+			<h2 id="performance" class="heading-medium">Performance</h2>
 			<ul class="list list-bullet">
 				<li>you can check the status of the platform on our <a href="https://status.cloud.service.gov.uk/">system status page</a></li>
 				<li>application logs can be streamed to SaaS logging platforms if service teams need to monitor app-specific performance metrics</li>
 				<li>service metrics can be captured from backing services</li>
 			</ul>
 
-			<h2 class="heading-medium">Support and maintenance</h2>
+			<h2 id="support-and-maintenance" class="heading-medium">Support and maintenance</h2>
 			<p>the GOV.UK PaaS team provides platform-level support 24/7. If your team is experiencing any issue using the platform we can provide assistance during office hours.</p>
 			<p>the GOV.UK PaaS team is in charge of monitoring the infrastructure, and patching operating systems and infrastructure components. We use zero downtime deploys, so upgrades to the PaaS won't interfere with the running of your application.</p>
 

--- a/views/privacy-notice.erb
+++ b/views/privacy-notice.erb
@@ -109,7 +109,7 @@
 			<p>You have the right to request:</p>
 			<ul class="list list-bullet">
 				<li>information about how your personal data is processed</li>
-				<li>a <a href="https://ico.org.uk/your-data-matters/your-right-of-access/" data-click-events data-click-category="Content" data-click-action="External link clicked">copy of that personal data</a> - this copy will be provided in a structured, commonly used and machine-readable format</li>
+				<li>a <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/" data-click-events data-click-category="Content" data-click-action="External link clicked">copy of that personal data</a> - this copy will be provided in a structured, commonly used and machine-readable format</li>
 				<li>that anything inaccurate in your personal data is corrected immediately </li>
 			</ul>
 			<p>You can also:</p>
@@ -131,7 +131,7 @@
 			<ul class="list list-bullet">
 				<li>have any questions about anything in this document</li>
 				<li>think that your personal data has been misused or mishandled</li>
-				<li>want to <a href="https://ico.org.uk/your-data-matters/your-right-of-access/" data-click-events data-click-category="Content" data-click-action="External link clicked">make a subject access request</a> (SARS)</li>
+				<li>want to <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/" data-click-events data-click-category="Content" data-click-action="External link clicked">make a subject access request</a> (SARS)</li>
 			</ul>
 
 			<p>Email: <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a></p>


### PR DESCRIPTION
What
----

I wanted to link directly to "Languages supported", but I can't because
the headings don't have IDs, and there are no anchors.

This will make it possible to link to
https://www.cloud.service.gov.uk/features#languages-supported

How to review
-------------

* Code review is probably enough

Who can review
--------------

Not @richardtowers