### PR TITLE
[Tenant Request] Update services hosted on GOV.UK PaaS

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -177,7 +177,7 @@
 				<p>
 					Several live services are currently using GOV.UK PaaS,
 					including Trade Tariff, GOV.UK Notify, Digital Marketplace,
-					DiT Horizon, BEIS Primary Authority Register and Her Majesty’s
+                                        <a href="https://great.gov.uk">great.gov.uk</a>, BEIS Primary Authority Register and Her Majesty’s
 					Prison and Probation Service.
 				</p>
 				<p>


### PR DESCRIPTION
What
----

DiT Horizon is now a defunct service so it has been updated with
great.gov.uk which is a current live service.

How to review
-------------

Code review

Who can review
--------------

Anyone
