### PR TITLE
Link to public Roadmap on GitHub

### DIFF
--- a/views/roadmap.erb
+++ b/views/roadmap.erb
@@ -14,42 +14,9 @@
 
 		<div class="column-two-thirds">
 			<h1 class="heading-xlarge">Roadmap</h1>
-			<p>This is what we plan to deliver in the coming months, and what we expect to work on longer term.</p>
-			<p>It’s a guide that’s updated regularly, and things might change.</p>
+			<p>We're using GitHub to better communicate our roadmap to our users.</p>
+			<p><a class="govuk-link" href="https://github.com/alphagov/paas-roadmap/projects/1?fullscreen=true">You can find our roadmap here.</a></p>
 			<p>To request a feature, ask any questions or provide any other feedback about GOV.UK PaaS, please get in touch with the team via <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a></p>
-
-			<h2 class="heading-medium">Features we've recently completed</h2>
-			<ul class="list list-bullet">
-				<li>S3 object storage</li>
-				<li>Non-crown offering</li>
-				<li>Support for Google and Microsoft single-sign on</li>
-				<li>Backing service metrics in admin tool</li>
-			</ul>
-
-			<h2 class="heading-medium">What we're working on next</h2>
-			<ul class="list list-bullet">
-				<li>Influx DB backing service enabling custom metrics for tenants (e.g. Prometheus on GOV.UK PaaS)</li>
-				<li>Expose a wider range of metrics in admin tool</li>
-				<li>Tenant tools for secrets management</li>
-				<li>Explore how we can offer tenants reserved instances of their databases</li>
-			</ul>
-
-			<h2 class="heading-medium">What we'll work on later (next 6 to 12 months)</h2>
-			<ul class="list list-bullet">
-  				<li>App autoscaling</li>
-					<li>Queues</li>
-				<li>Make it simpler to use CI/CD with the platform</li>
-			</ul>
-			<!--
-			<h2 class="heading-medium">Development stages</h2>
-			<p>Most features we’re building go through the following stages of development:</p>
-			<ul class="list list-bullet">
-				<li>alpha: exploring the problem space and investigating possible solutions</li>
-				<li>private beta: an early working version of the feature that’s tested by selected partners in a development environment - not suitable for use in production</li>
-				<li>public beta: a production-ready version of the feature that has been subjected to Cabinet Office/GDS information approval and security governance</li>
-				<li>live: a production-ready service that has been improved based on feedback during public beta</li>
-			</ul>
-			-->
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
What
----

Managing the ERB file is tedious and not for everyone. It requires HTML
knowledge at very least.

We've moved our roadmap to the GitHub Projects as it has access
controls and user friendly draggy and clicky interface.

How to review
-------------

- Review content
- Run locally
- Visit Roadmap page
- Consider if that's enough of a change