### PR TITLE
[#170049969] Add terms of use to product pages

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -96,6 +96,7 @@
 							<li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
 							<li><a href="/cookies">Cookies</a></li>
 							<li><a href="/privacy-notice">Privacy notice</a></li>
+							<li><a href="/terms-of-use">Terms of use</a></li>
 						</ul>
 					</nav>
 

--- a/views/terms-of-use.erb
+++ b/views/terms-of-use.erb
@@ -1,0 +1,235 @@
+<% content_for :head do %>
+	<title>Terms of use - <%= settings.title %></title>
+<% end %>
+
+<% content_for :breadcrumb do %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Cookies', href: request.path_info, active: true} %>
+<% end %>
+
+<div class="container">
+	<div class="grid-row">
+
+		<div class="column-two-thirds">
+			<h1 class="heading-large">Terms of Use for GOV.UK Platform as a Service</h1>
+			<p class="summary">You will need to read and agree to these Terms of Use before using GOV.UK PaaS.</p>
+
+            <h2 class="heading-medium">Changes we’ve made to the Terms of Use</h2>
+
+            <p class="bold-small">11 December 2019</p>
+
+            <p>Added requirement that tenants must regularly update their users and user permissions</p>
+
+            <p>Added requirement that tenants must get the right level of approval in their organisation before starting to use a paid quota</p>
+
+            <p>Clarified that emergency support is only available for live services</p>
+
+            <p>Removed requirement that tenants must comply with 12 factor development principles</p>
+
+            <p>Minor changes to make the Terms of Use more readable and accessible</p>
+
+            <p class="bold-small">21 June 2019</p>
+
+            <p>Various minor changes to account for non-Crown users and variable billing periods</p>
+
+            <p class="bold-small">29 April 2019</p>
+
+            <p>New references to Non Crown MOU</p>
+
+            <p class="bold-small">15 May 2018</p>
+
+            <p>Amendments to data policy</p>
+
+            <p class="bold-small">13 January 2017</p>
+
+            <p>Document approved</p>
+
+            <h2 class="heading-medium">Dependencies</h2>
+
+            <p>These Terms of Use mention the GOV.UK PaaS Memorandum of Understanding.</p>
+
+            <p>The GOV.UK PaaS Memorandum of Understanding has been agreed by your department or organisation. Any revision of these Terms of Use may also be issued as version update to the signatory of the Memorandum of Understanding.</p>
+
+            <h2 class="heading-medium">Terms of Use</h2>
+
+            <p>These Terms of Use apply to our and your service’s use of GOV.UK PaaS.</p>
+
+            <p>Before you host a live service or private data on GOV.UK PaaS, your government organisation must have accepted and signed the GOV.UK PaaS Memorandum of Understanding.</p>
+
+            <h2 class="heading-small">Summary</h2>
+
+            <p>If we accept your request to use GOV.UK PaaS, we agree to:</p>
+            <ul class="list list-bullet">
+                <li>host your service’s application or applications</li>
+                <li>ensure that GOV.UK PaaS complies with the service standard</li>
+                <li>ensure that GOV.UK PaaS has obtained suitable government security accreditation</li>
+                <li>maintain the security of GOV.UK PaaS</li>
+                <li>provide support for GOV.UK PaaS</li>
+                <li>minimise downtime of GOV.UK PaaS</li>
+                <li>alert you to any performance issue with GOV.UK PaaS</li>
+                <li>pass on the cost of hosting your service and its applications, including any backing services, via a regular invoice</li>
+                <li>continuously iterate GOV.UK PaaS in line with user needs</li>
+                <li>keep your data secure and comply with Data Protection Legislation/GDPR.</li>
+            </ul>
+
+            <p>You agree to:</p>
+            <ul class="list list-bullet">
+                <li>get the right level of approval in your organisation before you start using a paid quota</li>
+                <li>ensure that your service has passed government security accreditation and the Service Standard assessment, where necessary</li>
+                <li>only store data classified as ‘official’ and not store data classified as ‘secret’ or ‘top secret’</li>
+                <li>maintain the security of your applications</li>
+                <li>make sure you regularly update who has access to GOV.UK PaaS and their user permissions</li>
+                <li>not do anything which would, or is likely to, compromise the security or integrity of GOV.UK PaaS or its Sub-Contractors</li>
+                <li>tell us before you load or security test your service/applications</li>
+                <li>not load or security test GOV.UK PaaS or the underlying infrastructure</li>
+                <li>support your service/applications</li>
+                <li>support the users of your service/applications</li>
+                <li>let us know if you experience an issue with GOV.UK PaaS by using our ticketing system</li>
+                <li>agree to pay the costs as passed onto you by GOV.UK PaaS team.</li>
+            </ul>
+
+            <p>Before you can use GOV.UK PaaS for live services and private data you should have:</p>
+            <ul class="list list-bullet">
+                <li>signed the Memorandum of Understanding agreement, if your organisation has not already done so</li>
+                <li>informed the GOV.UK PaaS team that you intend to deploy a live service via <gov-uk-paas-support@digital.cabinet-office.gov.uk></li>
+                <li>asked them to upgrade the organisation (org) on GOV.UK PaaS where the service is hosted to a paid quota, if you have not already done so</li>
+                <li>obtained the relevant official level of security accreditation for your service/applications</li>
+                <li>signed this Terms of Use agreement.</li>
+            </ul>
+
+            <h2 class="heading-small">The agreement between GOV.UK PaaS and its users</h2>
+
+            <h2 class="heading-small">What GOV.UK PaaS agrees to do</h2>
+
+            <p class="bold-small">Host your development service/applications</p>
+
+            <p>We will provide you with a trial account and host your service’s development applications, providing all of the requirements summarised in these Terms of Use have been met.</p>
+
+            <p class="bold-small">Host your live service/applications</p>
+
+            <p>We will host your service’s live applications, provided the requirements summarised in this document have been met.</p>
+
+            <p class="bold-small">Ensure that GOV.UK PaaS complies with the Service Standard   </p>
+
+            <p>We will ensure that GOV.UK PaaS has passed the service assessment appropriate for its current level of development.</p>
+
+            <p class="bold-small">Ensure that GOV.UK PaaS has obtained its government security accreditation   </p>
+
+            <p>We will ensure that GOV.UK PaaS has been through the information assurance process to assess information and security risks, to determine appropriate treatments for those risks and to obtain risk acceptance from the Cabinet Office Senior Information Risk Officer (SIRO) for data classified as ‘official.’ This work includes the completion of a Screening Data Protection Impact Assessment (SDPIA), or Full Data Protection Impact Assessment (DPIA) (if required) to ensure compliance with the applicable Data Protection legislation/GDPR. Further information can be found in the ‘We agree to keep your data secure’ section below.</p>
+
+            <p class="bold-small">Maintain the security of GOV.UK PaaS   </p>
+
+            <p>We will inform you in a timely manner if GOV.UK PaaS experiences any security breaches.</p>
+
+            <p>We will perform penetration testing on GOV.UK PaaS, so that you don’t have to.</p>
+
+            <p>We will ensure that all security or vulnerability updates and patches are applied in a timely manner, and where relevant, we will tell you when we deploy them.</p>
+
+            <p class="bold-small">Provide support for GOV.UK PaaS   </p>
+
+            <p>GOV.UK PaaS provides 24/7 support for live services. We provide a ticketing system and escalation routes for service teams to address incidents.</p>
+
+            <p class="bold-small">Minimise down time of GOV.UK PaaS   </p>
+
+            <p>We have an internal alerting system that will tell us when GOV.UK PaaS is experiencing technical issues that may result in the loss of the platform, and we will take remedial action immediately.</p>
+
+            <p class="bold-small">Alert you to any issue GOV.UK PaaS is experiencing   </p>
+
+            <p>We will ensure that you are informed of any technical issues the platform experiences that may impact your service/applications. You can sign up to see the current status of GOV.UK PaaS and receive alerts on our Statuspage.</p>
+
+            <p class="bold-small">Invoice you regularly for using GOV.UK PaaS   </p>
+
+            <p>The GOV.UK PaaS team will invoice you regularly in arrears, for the cost of hosting your service/applications on GOV.UK PaaS. You will be invoiced either monthly, quarterly or annually, depending on your level of usage.</p>
+
+            <p class="bold-small">Continuously iterate GOV.UK PaaS in line with user needs   </p>
+
+            <p>The GOV.UK PaaS team will continuously iterate the platform in line with tenants’ needs throughout the lifetime of the product. GOV.UK PaaS will do this by ensuring that user research is an integral part of its development.</p>
+
+            <p class="bold-small">Keep your data secure   </p>
+
+            <p>GOV.UK PaaS will store and process tenant admin user data in accordance with our <a href="/privacy-notice" data-click-events data-click-category="Content" data-click-action="Internal link clicked">privacy policy</a>. A Data Processing Agreement is contained with the Memorandum of Understanding in which both parties obligations towards Data Protection are set out.</p>
+
+            <p>GOV.UK PaaS will store and process tenant data in accordance with our Memorandum of Understanding and Terms of Use.</p>
+
+            <p>You are responsible for the protection and security of the data used by your applications in compliance with applicable Data Protection Legislation/GDPR.</p>
+
+            <p>GOV.UK PaaS has been through an information assurance process which includes the completion of a Screening Data Protection Impact Assessment (SDPIA) and Full Data Protection Impact Assessment to ensure compliance with the applicable Data Protection Legislation/GDPR.</p>
+
+            <p>Cabinet Office/GDS act as Data Processor within the meaning of the Data Protection Legislation/GDPR, as parent organisation of GOV.UK PaaS. Your organisation remains the Data Controller within the meaning of the Data Protection Legislation/GDPR.</p>
+
+            <p>If we receive Subject Access Requests which relate to data held by your team or product, we will pass tenants’ details to the GDS channel that made the request to ensure compliance with Data Protection Legislation in order to meet both parties obligations.</p>
+
+            <p>We maintain appropriate technical and organisational measures to protect data. We make sure our sub-contractors follow the same procedures.</p>
+
+            <p class="bold-small">Give you at least 30 days notice if we change these terms   </p>
+
+            <p>Any change to these terms will be reflected in this document under "Changes we’ve made to the Terms of Use", and will take immediate effect.</p>
+
+            <p>Section 4.8 of the GOV.UK PaaS Memorandum of Understanding for Crown Tenants describes the document change management.</p>
+
+            <p>Section 5 of the GOV.UK PaaS Memorandum of Understanding for Non Crown Tenants describes the document change management.</p>
+
+            <h2 class="heading-small">What you as a user agree to do</h2>
+
+            <p class="bold-small">Get the right level of approval in your organisation before you start using a paid quota   </p>
+
+            <p>You agree to get approval from the appropriate person or people in your organisation before you ask your GOV.UK PaaS account to be upgraded to a paid quota.</p>
+
+            <p class="bold-small">Ensure that your service complies with the Service Standard (where necessary) and has passed government security accreditation.   </p>
+
+            <p>You agree to ensure that your service has passed the appropriate Service Standard assessment, where necessary.</p>
+
+            <p>You agree to assure your service through your organisation’s information assurance (security) process, as required by your organisation. You don’t need to include assurance of GOV.UK PaaS, since we’ve already done that. We can share the work we’ve done with you.</p>
+
+            <p class="bold-small">Maintain the security of your applications   </p>
+
+            <p>You will secure access to your application and ensure that it has all relevant security and vulnerability updates and patches applied in a timely manner.</p>
+
+            <p>You will collect and store any logs that you require in order to manage or investigate the operation of your application.</p>
+
+            <p class="bold-small">Make sure you regularly update who has access to GOV.UK PaaS and their user permissions   </p>
+
+            <p>You will regularly review and update the list of users in your GOV.UK PaaS account to ensure that the correct people have access, and that any people who have left your service team have their permissions removed.</p>
+
+            <p>You will ensure that you have used the user management tools provided by GOV.UK PaaS to specify an Organisation Manager (with a government or public sector email address).</p>
+
+            <p>You will ensure that you have used the user management tools provided by GOV.UK PaaS to specify a Billing Manager (with a government or public sector email address), who will be responsible for paying for the service.</p>
+
+            <p class="bold-small">Not compromise the security or integrity of GOV.UK PaaS or any GOV.UK PaaS sub-contractor   </p>
+
+            <p>You must tell us immediately if you experience any security breaches and comply with the notifications required under the Data Protection Legislation (para 1.8.3 under the Crown Tenant Data Processing Agreement and Schedule 1 para 2.5.6 under the Non Crown Tenant Data Processing Agreement). This is so we can make sure other services running on GOV.UK PaaS, or our sub-contractors, are not affected and that both parties comply with obligations under the Data Protection Legislation/GDPR.</p>
+
+            <p>You must follow industry best practices for keeping your API keys and other credentials secure.</p>
+
+            <p>You must notify us at least 14 days before performing any load or security testing on your application hosted with GOV.UK PaaS.</p>
+
+            <p>You must not conduct any load or security testing on GOV.UK PaaS itself, nor the underlying infrastructure, since we’ve already done that - we can share the work we’ve done with you.</p>
+
+            <p class="bold-small">Support the service/applications that are hosted on GOV.UK PaaS   </p>
+
+            <p>You are responsible for providing technical support for your service/applications while it is hosted on GOV.UK PaaS. GOV.UK PaaS team will only provide technical support for the availability of the platform itself.</p>
+
+            <p class="bold-small">Provide user support for the users of your service/applications   </p>
+
+            </p>You are responsible for continuing to provide user support (including assisted digital support) for the users of your service/applications.</p>
+
+            <p class="bold-small">Let us know if you experience an issue with GOV.UK PaaS via our ticketing system   </p>
+
+            <p>If you experience an issue with GOV.UK PaaS, you will let us know via our ticketing system.</p>
+
+            <p class="bold-small">Pay for the hosting resources your service/applications use, including for any backing services, which GOV.UK PaaS team will pass on to you   </p>
+
+            <p>You will pay the invoice you receive from Government Digital Service charging you for the space you use to host your service/applications and additional backing services and additional platform costs. A full breakdown of what we charge for is in section 4.1 of the Crown Tenant Memorandum of Understanding or at Schedule 2 of the non Crown Tenant Memorandum of Understanding.</p>
+
+            <p>You will pay this invoice in full within 30 days.</p>
+
+            <h2 class="heading-small">Leaving GOV.UK PaaS</h2>
+
+            <p>Please let the GOV.UK PaaS team know if you want to remove your service/applications from the platform by emailing <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>. We’ll close your account and all of your data will be deleted.</p>
+
+            <h2 class="heading-small">Suspending or Removing a Service</h2>
+
+            <p>GOV.UK PaaS may suspend or remove a service if it is in significant breach of these Terms of Use.</p>
+
+		</div>
+	</div>
+</div>

--- a/views/terms-of-use.erb
+++ b/views/terms-of-use.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :breadcrumb do %>
-	<%== erb :'partials/_breadcrumb', :locals => {name: 'Cookies', href: request.path_info, active: true} %>
+	<%== erb :'partials/_breadcrumb', :locals => {name: 'Terms of Use', href: request.path_info, active: true} %>
 <% end %>
 
 <div class="container">
@@ -90,7 +90,7 @@
             <p>Before you can use GOV.UK PaaS for live services and private data you should have:</p>
             <ul class="list list-bullet">
                 <li>signed the Memorandum of Understanding agreement, if your organisation has not already done so</li>
-                <li>informed the GOV.UK PaaS team that you intend to deploy a live service via <gov-uk-paas-support@digital.cabinet-office.gov.uk></li>
+                <li>informed the GOV.UK PaaS team that you intend to deploy a live service via <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a></li>
                 <li>asked them to upgrade the organisation (org) on GOV.UK PaaS where the service is hosted to a paid quota, if you have not already done so</li>
                 <li>obtained the relevant official level of security accreditation for your service/applications</li>
                 <li>signed this Terms of Use agreement.</li>
@@ -204,15 +204,15 @@
 
             <p>You must not conduct any load or security testing on GOV.UK PaaS itself, nor the underlying infrastructure, since we’ve already done that - we can share the work we’ve done with you.</p>
 
-            <p class="bold-small">Support the service/applications that are hosted on GOV.UK PaaS   </p>
+            <p class="bold-small">Support the service/applications that are hosted on GOV.UK PaaS</p>
 
             <p>You are responsible for providing technical support for your service/applications while it is hosted on GOV.UK PaaS. GOV.UK PaaS team will only provide technical support for the availability of the platform itself.</p>
 
-            <p class="bold-small">Provide user support for the users of your service/applications   </p>
+            <p class="bold-small">Provide user support for the users of your service/applications</p>
 
-            </p>You are responsible for continuing to provide user support (including assisted digital support) for the users of your service/applications.</p>
+            <p>You are responsible for continuing to provide user support (including assisted digital support) for the users of your service/applications.</p>
 
-            <p class="bold-small">Let us know if you experience an issue with GOV.UK PaaS via our ticketing system   </p>
+            <p class="bold-small">Let us know if you experience an issue with GOV.UK PaaS via our ticketing system</p>
 
             <p>If you experience an issue with GOV.UK PaaS, you will let us know via our ticketing system.</p>
 
@@ -224,7 +224,7 @@
 
             <h2 class="heading-small">Leaving GOV.UK PaaS</h2>
 
-            <p>Please let the GOV.UK PaaS team know if you want to remove your service/applications from the platform by emailing <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>. We’ll close your account and all of your data will be deleted.</p>
+            <p>Please let the GOV.UK PaaS team know if you want to remove your service/applications from the platform by emailing <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>. We’ll close your account and all of your data will be deleted.</p>
 
             <h2 class="heading-small">Suspending or Removing a Service</h2>
 


### PR DESCRIPTION
What
----

It is a good idea to make sure that our terms of use are able to be read
at any time by our tenants as it make it easy to reference roles and
responsibilities.

How to review
-------------

Code review, check that it renders correctly locally

Who can review
--------------

Anyone
