### PR TITLE
Add link to Marketplace on features page

### DIFF
--- a/views/features.erb
+++ b/views/features.erb
@@ -46,14 +46,11 @@
 			  <li>a static HTML/CSS/Javascript site</li>
 			  <li>a compiled binary</li>
 			</ul></li>
-			<li>backing services including:
-			<ul class="list list-bullet">
-			<li>Elasticsearch</li>
-			<li>MySQL</li>
-			<li>PostgreSQL</li>
-			<li>Redis</li>
-			<li>S3</li>
-			</ul></li>
+			<li>
+				<a href="https://admin.london.cloud.service.gov.uk/marketplace">
+					managed backing services
+				</a> including PostgreSQL, Elasticsearch, and Amazon S3.
+			</li>
 			<li><a href="/observability">observability for your apps</a> including support for logs, metrics and tracing.</li>
 			</ul>
 


### PR DESCRIPTION
What
----

We now list the services on a separate page, which has detailed
information, and should be accessible from the product page

How to review
-------------

Review the words

Perhaps preview locally

Who can review
--------------

Not @tlwr