### PR TITLE
[#172581941] Show a more user-friendly error message if the ZenDesk API returns an error

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -81,7 +81,7 @@ class App < Sinatra::Base
 				erb :'forms/thanks'
 			rescue => ex
 				status 500
-				@errors[:fatal] = [ex.to_s]
+				@errors[:fatal] = [Forms::UNKNOWN_ERROR_MESSAGE]
 				erb :'forms/contact-us'
 			end
 		end
@@ -123,7 +123,7 @@ class App < Sinatra::Base
 				erb :'forms/thanks'
 			rescue => ex
 				status 500
-				@errors[:fatal] = [ex.to_s]
+				@errors[:fatal] = [Forms::UNKNOWN_ERROR_MESSAGE]
 				erb :'forms/signup'
 			end
 		end
@@ -217,7 +217,7 @@ class App < Sinatra::Base
 				end
 			rescue => ex
 				status 500
-				@errors[:fatal] = [ex.to_s]
+				@errors[:fatal] = [Forms::UNKNOWN_ERROR_MESSAGE]
 				erb(path.to_sym)
 			end
 		end

--- a/models/forms.rb
+++ b/models/forms.rb
@@ -2,6 +2,7 @@ require './models/model'
 
 module Forms
 	VALID_EMAIL_REGEX = /.+@.+\..+/
+	UNKNOWN_ERROR_MESSAGE = "Your request could not be submitted through this form. Please email govuk-paas-support@digital.cabinet-office.gov.uk directly."
 
 	class GenericContact < Model
 		MAX_FIELD_LEN = 2048


### PR DESCRIPTION
What
----

Previously we showed the full error message back to the user. They don't need
to see that. They need instructing to email us directly.

How to review
-------------
Code review should be enough. The logic hasn't changed.

Who can review
--------------
Anyone